### PR TITLE
Externalize constants

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,7 +42,7 @@ jobs:
       
       # - run: npm run dist
 
-      # - run: npm test
+      - run: npm test
 
       - run: npm config set '//registry.npmjs.org/:_authToken' "${{ secrets.NPM_AUTH_TOKEN }}"
 

--- a/__tests__/unit/file-utils.test.ts
+++ b/__tests__/unit/file-utils.test.ts
@@ -2,12 +2,7 @@
  * @jest-environment jsdom
  */
 
-import {
-  getFileExtension,
-  setMimeType,
-  correctFileType,
-} from '../../src/utils/files'
-import { ERROR_MESSAGES, FILE_UPLOAD_SIZE_LIMIT } from '../../src/constants'
+import { getFileExtension } from '../../src/utils/files'
 
 describe('unit test - file utils', () => {
   test('get file extension', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import 'isomorphic-unfetch'
 import { request } from 'graphql-request'
-import { MintbaseAPIConfig, Network, Chain, Token } from './types'
+import { MintbaseAPIConfig, Network, Chain, Token, Constants } from './types'
 import { API_BASE_NEAR_TESTNET, BASE_ARWEAVE_URI } from './constants'
 import {
   FETCH_MARKETPLACE,
@@ -8,6 +8,7 @@ import {
   GET_TOKENS_BY_OWNER_ID,
   GET_TOKEN_BY_ID,
 } from './queries'
+import { initializeExternalConstants } from './utils/external-constants'
 
 /**
  * Mintbase API.
@@ -17,17 +18,27 @@ export class API {
   public apiBaseUrl: string = API_BASE_NEAR_TESTNET
   public defaultLimit = 10
   public chainName: string = Chain.near
-  public networkName: string = Network.testnet
+  public networkName: Network = Network.testnet
 
-  constructor(config: MintbaseAPIConfig) {
-    switch (config.chain) {
+  public constants: Constants
+
+  constructor(apiConfig: MintbaseAPIConfig) {
+    this.constants = apiConfig.constants
+
+    switch (apiConfig.chain) {
       case Chain.near:
-        this.apiBaseUrl = config.apiBaseUrl || API_BASE_NEAR_TESTNET
+        this.apiBaseUrl =
+          this.constants.API_BASE_NEAR_TESTNET ||
+          apiConfig.apiBaseUrl ||
+          API_BASE_NEAR_TESTNET
         this.chainName = Chain.near
         break
       default:
-        this.apiBaseUrl = config.apiBaseUrl || API_BASE_NEAR_TESTNET
-        this.chainName = config.chain || Chain.near
+        this.apiBaseUrl =
+          this.constants.API_BASE_NEAR_TESTNET ||
+          apiConfig.apiBaseUrl ||
+          API_BASE_NEAR_TESTNET
+        this.chainName = apiConfig.chain || Chain.near
         break
     }
   }
@@ -126,7 +137,9 @@ export class API {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async fetchMetadata(id: string): Promise<any> {
-    const request = await fetch(`${BASE_ARWEAVE_URI}/${id}`)
+    const request = await fetch(
+      `${this.constants.BASE_ARWEAVE_URI || BASE_ARWEAVE_URI}/${id}`
+    )
     const result = await request.json()
     return result
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,14 +1,17 @@
 import 'isomorphic-unfetch'
 import { request } from 'graphql-request'
 import { MintbaseAPIConfig, Network, Chain, Token, Constants } from './types'
-import { API_BASE_NEAR_TESTNET, BASE_ARWEAVE_URI } from './constants'
+import {
+  API_BASE_NEAR_MAINNET,
+  API_BASE_NEAR_TESTNET,
+  BASE_ARWEAVE_URI,
+} from './constants'
 import {
   FETCH_MARKETPLACE,
   GET_LATEST_LIST,
   GET_TOKENS_BY_OWNER_ID,
   GET_TOKEN_BY_ID,
 } from './queries'
-import { initializeExternalConstants } from './utils/external-constants'
 
 /**
  * Mintbase API.
@@ -18,19 +21,28 @@ export class API {
   public apiBaseUrl: string = API_BASE_NEAR_TESTNET
   public defaultLimit = 10
   public chainName: string = Chain.near
-  public networkName: Network = Network.testnet
+  public networkName: Network | undefined
 
   public constants: Constants
 
   constructor(apiConfig: MintbaseAPIConfig) {
     this.constants = apiConfig.constants
 
+    this.networkName = apiConfig.networkName || Network.testnet
+
     switch (apiConfig.chain) {
       case Chain.near:
-        this.apiBaseUrl =
-          this.constants.API_BASE_NEAR_TESTNET ||
-          apiConfig.apiBaseUrl ||
-          API_BASE_NEAR_TESTNET
+        if (this.networkName === Network.testnet) {
+          this.apiBaseUrl =
+            this.constants.API_BASE_NEAR_TESTNET ||
+            apiConfig.apiBaseUrl ||
+            API_BASE_NEAR_TESTNET
+        } else if (this.networkName === Network.mainnet) {
+          this.apiBaseUrl =
+            this.constants.API_BASE_NEAR_MAINNET ||
+            apiConfig.apiBaseUrl ||
+            API_BASE_NEAR_MAINNET
+        }
         this.chainName = Chain.near
         break
       default:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,26 +1,23 @@
 import BN from 'bn.js'
 import { MetadataField } from './types'
 
-export const API_VERSION = 1
+export const API_VERSION = '1'
 export const API_BASE_NEAR_MAINNET =
+  process.env.MINTBASEJS_API_BASE_NEAR_MAINNET ||
   'https://mintbase-mainnet.hasura.app/v1/graphql'
 export const API_BASE_NEAR_TESTNET =
+  process.env.MINTBASEJS_API_BASE_NEAR_TESTNET ||
   'https://mintbase-testnet.hasura.app/v1/graphql'
 export const BASE_ARWEAVE_URI = 'https://arweave.net'
 
 export const CLOUD_BASE_URI = process.env.MINTBASEJS_CLOUD_URI
-export const CLOUD_GET_FILE_METADATA_URI = (fileName: string): string =>
-  `${CLOUD_BASE_URI}/arweave/file/${fileName}`
-export const CLOUD_POST_METADATA_URI = (): string =>
-  `${CLOUD_BASE_URI}/arweave/metadata/`
 
 export const DEFAULT_APP_NAME = 'Mintbase.js'
 export const NEAR_LOCAL_STORAGE_KEY_SUFFIX = '_wallet_auth_key'
 
 // TODO: pull this from somewhere else?
-export const STORE_FACTORY_CONTRACT_NAME =
-  process.env.CONTRACT_NAME || 'mintspace1.testnet'
-export const MARKET_ACCOUNT = `0.${STORE_FACTORY_CONTRACT_NAME}`
+export const FACTORY_CONTRACT_NAME =
+  process.env.MINTBASEJS_FACTORY_CONTRACT_NAME || 'mintspace.testnet'
 
 export const STORE_CONTRACT_VIEW_METHODS = []
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,9 @@
 import BN from 'bn.js'
 import { MetadataField } from './types'
 
-export const API_VERSION = '1'
+export const CLOUD_URI = process.env.MINTBASEJS_CLOUD_URI
+export const API_VERSION = process.env.MINTBASEJS_API_VERSION || '1'
+
 export const API_BASE_NEAR_MAINNET =
   process.env.MINTBASEJS_API_BASE_NEAR_MAINNET ||
   'https://mintbase-mainnet.hasura.app/v1/graphql'
@@ -9,8 +11,6 @@ export const API_BASE_NEAR_TESTNET =
   process.env.MINTBASEJS_API_BASE_NEAR_TESTNET ||
   'https://mintbase-testnet.hasura.app/v1/graphql'
 export const BASE_ARWEAVE_URI = 'https://arweave.net'
-
-export const CLOUD_BASE_URI = process.env.MINTBASEJS_CLOUD_URI
 
 export const DEFAULT_APP_NAME = 'Mintbase.js'
 export const NEAR_LOCAL_STORAGE_KEY_SUFFIX = '_wallet_auth_key'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const NEAR_LOCAL_STORAGE_KEY_SUFFIX = '_wallet_auth_key'
 
 // TODO: pull this from somewhere else?
 export const FACTORY_CONTRACT_NAME =
-  process.env.MINTBASEJS_FACTORY_CONTRACT_NAME || 'mintspace.testnet'
+  process.env.MINTBASEJS_FACTORY_CONTRACT_NAME || 'mintspace1.testnet'
 
 export const STORE_CONTRACT_VIEW_METHODS = []
 

--- a/src/minter.ts
+++ b/src/minter.ts
@@ -121,6 +121,8 @@ export class Minter {
     error: null | string
   }> {
     try {
+      if (!this.storage) throw new Error('Storage not initialized')
+
       // corrects MIME type.
       const tFile = await correctFileType(file)
 
@@ -129,8 +131,6 @@ export class Minter {
         (this.constants.FILE_UPLOAD_SIZE_LIMIT || FILE_UPLOAD_SIZE_LIMIT)
       )
         throw new Error(ERROR_MESSAGES.fileSizeExceeded)
-
-      if (!this.storage) throw new Error('Storage not initialized')
 
       const result = await this.storage.uploadToArweave(file)
 

--- a/src/minter.ts
+++ b/src/minter.ts
@@ -7,12 +7,11 @@ import {
 } from './constants'
 import { Constants, MetadataField } from './types'
 import { correctFileType } from './utils/files'
-import { initializeExternalConstants } from './utils/external-constants'
 import { Storage } from './utils/storage'
 
 interface MinterConfigProps {
   apiKey?: string
-  constants: Constants
+  constants?: Constants
 }
 
 /**
@@ -29,14 +28,17 @@ export class Minter {
   public apiKey: string
   public constants: Constants
 
-  constructor(minterConfig: MinterConfigProps) {
+  constructor(minterConfig: MinterConfigProps = {}) {
     this.latestMints = {}
     this.currentMint = {}
 
-    this.constants = minterConfig.constants
+    this.constants = minterConfig.constants || {}
     this.apiKey = minterConfig.apiKey || 'anonymous'
 
-    this.storage = new Storage({ constants: this.constants })
+    this.storage = new Storage({
+      apiKey: this.apiKey,
+      constants: this.constants,
+    })
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ enum Chain {
 }
 
 enum Network {
-  main = 'main',
+  mainnet = 'mainnet',
   testnet = 'testnet',
 }
 
@@ -36,7 +36,6 @@ interface Constants {
   API_BASE_NEAR_MAINNET?: string
   API_BASE_NEAR_TESTNET?: string
   BASE_ARWEAVE_URI?: string
-  CLOUD_BASE_URI?: string
   FACTORY_CONTRACT_NAME?: string
   STORE_CONTRACT_VIEW_METHODS?: string[]
   STORE_CONTRACT_CALL_METHODS?: string[]
@@ -214,5 +213,5 @@ export {
   NEARConfig,
   Constants,
   CloudStorageConstants,
-  WalletConfig
+  WalletConfig,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,38 @@ interface List {
   currentOfferId?: string
 }
 
+interface Constants {
+  API_VERSION?: string
+  API_BASE_NEAR_MAINNET?: string
+  API_BASE_NEAR_TESTNET?: string
+  BASE_ARWEAVE_URI?: string
+  CLOUD_BASE_URI?: string
+  FACTORY_CONTRACT_NAME?: string
+  STORE_CONTRACT_VIEW_METHODS?: string[]
+  STORE_CONTRACT_CALL_METHODS?: string[]
+  MARKET_CONTRACT_VIEW_METHODS?: string[]
+  MARKET_CONTRACT_CALL_METHODS?: string[]
+  FACTORY_CONTRACT_VIEW_METHODS?: string[]
+  FACTORY_CONTRACT_CALL_METHODS?: string[]
+  CLOUD_STORAGE_CONFIG?: CloudStorageConstants
+  DEFAULT_ROYALTY_PERCENT?: number
+  FILE_UPLOAD_SIZE_LIMIT?: number
+}
+
+interface CloudStorageConstants {
+  apiKey: string
+  authDomain: string
+  databaseURL: string
+  projectId: string
+  storageBucket: string
+}
+
+interface WalletConfig {
+  apiKey: string
+  chain?: Chain
+  networkName?: Network
+}
+
 /**
  * Mintbase API configuration object
  * @param chain `Chain` type to use. Defaults to `Chain.near`
@@ -42,6 +74,7 @@ interface MintbaseAPIConfig {
   networkName?: Network
   apiBaseUrl?: string
   apiKey?: string
+  constants: Constants
 }
 
 interface WalletLoginProps {
@@ -179,4 +212,7 @@ export {
   MetadataField,
   MintMetadata,
   NEARConfig,
+  Constants,
+  CloudStorageConstants,
+  WalletConfig
 }

--- a/src/utils/external-constants.ts
+++ b/src/utils/external-constants.ts
@@ -1,6 +1,6 @@
 import 'isomorphic-unfetch'
 import { Constants, Network } from 'src/types'
-import { CLOUD_BASE_URI, API_VERSION } from '../constants'
+import { CLOUD_URI, API_VERSION } from '../constants'
 
 export const initializeExternalConstants = async ({
   apiKey,
@@ -9,7 +9,7 @@ export const initializeExternalConstants = async ({
   apiKey?: string
   networkName?: Network
 }): Promise<Constants> => {
-  const response = await fetch(`${CLOUD_BASE_URI}/developer`, {
+  const response = await fetch(`${CLOUD_URI}/developer`, {
     headers: {
       'api-key': apiKey || 'anonymous',
       'api-version': API_VERSION,

--- a/src/utils/external-constants.ts
+++ b/src/utils/external-constants.ts
@@ -12,7 +12,9 @@ export const initializeExternalConstants = async ({
   const response = await fetch(`${CLOUD_URI}/developer`, {
     headers: {
       'api-key': apiKey || 'anonymous',
-      'api-version': API_VERSION,
+      'api-version': !networkName
+        ? API_VERSION
+        : `${API_VERSION}-${networkName}`,
     },
   })
 

--- a/src/utils/external-constants.ts
+++ b/src/utils/external-constants.ts
@@ -1,0 +1,20 @@
+import 'isomorphic-unfetch'
+import { Constants, Network } from 'src/types'
+import { CLOUD_BASE_URI, API_VERSION } from '../constants'
+
+export const initializeExternalConstants = async ({
+  apiKey,
+  networkName,
+}: {
+  apiKey?: string
+  networkName?: Network
+}): Promise<Constants> => {
+  const response = await fetch(`${CLOUD_BASE_URI}/developer`, {
+    headers: {
+      'api-key': apiKey || 'anonymous',
+      'api-version': API_VERSION,
+    },
+  })
+
+  return await response.json()
+}

--- a/src/utils/near-costs.ts
+++ b/src/utils/near-costs.ts
@@ -3,5 +3,5 @@ const MARKET_LIST_COST = 0.0035
 const APPROVAL_STORAGE = 0.0008
 
 export const calculateListCost = (amount: number): number => {
-  return (APPROVAL_STORAGE * COST_PER_BYTE + MARKET_LIST_COST) * amount
+  return (APPROVAL_STORAGE + COST_PER_BYTE + MARKET_LIST_COST) * amount
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -3,12 +3,7 @@ import firebase from 'firebase/app'
 import 'firebase/storage'
 import { isNode } from 'browser-or-node'
 import { v4 as uuidv4 } from 'uuid'
-import {
-  CLOUD_BASE_URI,
-  CLOUD_STORAGE_CONFIG,
-  ERROR_MESSAGES,
-} from '../constants'
-import { initializeExternalConstants } from './external-constants'
+import { CLOUD_URI, CLOUD_STORAGE_CONFIG, ERROR_MESSAGES } from '../constants'
 import { Constants } from 'src/types'
 
 const ARWEAVE_FOLDER = 'arweave'
@@ -49,16 +44,13 @@ export class Storage {
    */
   public async uploadMetadata(metadata: unknown): Promise<string> {
     try {
-      const request = await fetch(
-        `${this.constants.CLOUD_BASE_URI || CLOUD_BASE_URI}/arweave/metadata/`,
-        {
-          method: 'POST',
-          body: JSON.stringify(metadata),
-          headers: {
-            [headers.apiKey]: this.apiKey || 'anonymous',
-          },
-        }
-      )
+      const request = await fetch(`${CLOUD_URI}/arweave/metadata/`, {
+        method: 'POST',
+        body: JSON.stringify(metadata),
+        headers: {
+          [headers.apiKey]: this.apiKey || 'anonymous',
+        },
+      })
       const data = await request.json()
 
       return data?.id as string
@@ -87,16 +79,11 @@ export class Storage {
 
       try {
         // Fetches arweave id. This request will trigger an upload in the cloud
-        const request = await fetch(
-          `${
-            this.constants.CLOUD_BASE_URI || CLOUD_BASE_URI
-          }/arweave/file/${fileName}`,
-          {
-            headers: {
-              [headers.apiKey]: this.apiKey || 'anonymous',
-            },
-          }
-        )
+        const request = await fetch(`${CLOUD_URI}/arweave/file/${fileName}`, {
+          headers: {
+            [headers.apiKey]: this.apiKey || 'anonymous',
+          },
+        })
 
         const data = await request.json()
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -13,7 +13,7 @@ const headers = {
 
 interface StorageConfigProps {
   apiKey?: string
-  constants: Constants
+  constants?: Constants
 }
 
 export class Storage {
@@ -24,8 +24,8 @@ export class Storage {
 
   public constants: Constants
 
-  constructor(storageConfig: StorageConfigProps) {
-    this.constants = storageConfig.constants
+  constructor(storageConfig: StorageConfigProps = {}) {
+    this.constants = storageConfig.constants || {}
     this.apiKey = storageConfig.apiKey || 'anonymous'
 
     if (!firebase.apps.length) {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -4,104 +4,136 @@ import 'firebase/storage'
 import { isNode } from 'browser-or-node'
 import { v4 as uuidv4 } from 'uuid'
 import {
-  CLOUD_GET_FILE_METADATA_URI,
-  CLOUD_POST_METADATA_URI,
+  CLOUD_BASE_URI,
   CLOUD_STORAGE_CONFIG,
   ERROR_MESSAGES,
 } from '../constants'
+import { initializeExternalConstants } from './external-constants'
+import { Constants } from 'src/types'
 
-if (!firebase.apps.length) {
-  firebase.initializeApp(CLOUD_STORAGE_CONFIG)
-}
-
-const storage = firebase.storage()
 const ARWEAVE_FOLDER = 'arweave'
-
 const headers = {
   apiKey: 'api-key',
 }
 
-/**
- * Uploads raw binary data to the cloud. This method is useful because
- * we can trigger an arweave upload via an http request with the returned file name.
- * @param buffer the raw binary data of the file to upload
- * @param contentType the content type
- * @returns the filename
- */
-const _uploadCloud = async (
-  buffer: ArrayBuffer | Buffer,
-  contentType: string
-): Promise<string> => {
-  if (isNode) throw new Error('Node environment does not yet supports uploads.')
-  try {
-    const fileName = uuidv4()
-    await storage
-      .ref(`${ARWEAVE_FOLDER}/${fileName}`)
-      .put(buffer, { contentType: contentType })
-    return fileName
-  } catch (error) {
-    throw new Error(ERROR_MESSAGES.uploadCloud)
-  }
+interface StorageConfigProps {
+  apiKey?: string
+  constants: Constants
 }
 
-/**
- * Upload file to Arweave via a cloud function
- * @param file the file to upload
- * @returns retunrns an object containing the arweave content identifier and the content type.
- */
-export const uploadToArweave = async (
-  file: File,
-  apiKey?: string
-): Promise<{ id: string; contentType: string }> => {
-  if (isNode) throw new Error('Node environment does not yet supports uploads.')
+export class Storage {
+  public firebase: firebase.app.App | undefined
+  public storage: firebase.storage.Storage | undefined
 
-  const buffer = await file.arrayBuffer()
-  const contentType = file.type
+  public apiKey: string
 
-  try {
-    // Uploads to google cloud
-    const fileName = await _uploadCloud(buffer, contentType)
+  public constants: Constants
 
+  constructor(storageConfig: StorageConfigProps) {
+    this.constants = storageConfig.constants
+    this.apiKey = storageConfig.apiKey || 'anonymous'
+
+    if (!firebase.apps.length) {
+      this.firebase = firebase.initializeApp(
+        this.constants.CLOUD_STORAGE_CONFIG || CLOUD_STORAGE_CONFIG
+      )
+
+      this.storage = this.firebase.storage()
+    }
+  }
+
+  /**
+   * Uploads metadata to Arweave via a cloud function
+   * @param metadata metadata object
+   * @returns arweave content identifier
+   */
+  public async uploadMetadata(metadata: unknown): Promise<string> {
     try {
-      // Fetches arweave id. This request will trigger an upload in the cloud
-      const request = await fetch(CLOUD_GET_FILE_METADATA_URI(fileName), {
-        headers: {
-          [headers.apiKey]: apiKey || 'anonymous',
-        },
-      })
-
+      const request = await fetch(
+        `${this.constants.CLOUD_BASE_URI || CLOUD_BASE_URI}/arweave/metadata/`,
+        {
+          method: 'POST',
+          body: JSON.stringify(metadata),
+          headers: {
+            [headers.apiKey]: this.apiKey || 'anonymous',
+          },
+        }
+      )
       const data = await request.json()
 
-      return { id: data?.id, contentType: data?.contentType }
+      return data?.id as string
     } catch (error) {
-      throw new Error(ERROR_MESSAGES.decentralizedStorageFailed)
+      throw new Error(ERROR_MESSAGES.uploadMetadata)
     }
-  } catch (error) {
-    throw new Error(error.message)
   }
-}
 
-/**
- * Uploads metadata to Arweave via a cloud function
- * @param metadata metadata object
- * @returns arweave content identifier
- */
-export const uploadMetadata = async (
-  metadata: unknown,
-  apiKey?: string
-): Promise<string> => {
-  try {
-    const request = await fetch(CLOUD_POST_METADATA_URI(), {
-      method: 'POST',
-      body: JSON.stringify(metadata),
-      headers: {
-        [headers.apiKey]: apiKey || 'anonymous',
-      },
-    })
-    const data = await request.json()
+  /**
+   * Upload file to Arweave via a cloud function
+   * @param file the file to upload
+   * @returns retunrns an object containing the arweave content identifier and the content type.
+   */
+  public async uploadToArweave(
+    file: File
+  ): Promise<{ id: string; contentType: string }> {
+    if (isNode)
+      throw new Error('Node environment does not yet supports uploads.')
 
-    return data?.id as string
-  } catch (error) {
-    throw new Error(ERROR_MESSAGES.uploadMetadata)
+    const buffer = await file.arrayBuffer()
+    const contentType = file.type
+
+    try {
+      // Uploads to google cloud
+      const fileName = await this.uploadCloud(buffer, contentType)
+
+      try {
+        // Fetches arweave id. This request will trigger an upload in the cloud
+        const request = await fetch(
+          `${
+            this.constants.CLOUD_BASE_URI || CLOUD_BASE_URI
+          }/arweave/file/${fileName}`,
+          {
+            headers: {
+              [headers.apiKey]: this.apiKey || 'anonymous',
+            },
+          }
+        )
+
+        const data = await request.json()
+
+        return { id: data?.id, contentType: data?.contentType }
+      } catch (error) {
+        throw new Error(ERROR_MESSAGES.decentralizedStorageFailed)
+      }
+    } catch (error) {
+      throw new Error(error.message)
+    }
+  }
+
+  /**
+   * Uploads raw binary data to the cloud. This method is useful because
+   * we can trigger an arweave upload via an http request with the returned file name.
+   * @param buffer the raw binary data of the file to upload
+   * @param contentType the content type
+   * @returns the filename
+   */
+  private async uploadCloud(
+    buffer: ArrayBuffer | Buffer,
+    contentType: string
+  ): Promise<string> {
+    if (isNode)
+      throw new Error('Node environment does not yet supports uploads.')
+    try {
+      const fileName = uuidv4()
+
+      if (!this.storage) throw new Error('Storage is not initialized')
+
+      await this.storage
+        .ref(`${ARWEAVE_FOLDER}/${fileName}`)
+        .put(buffer, { contentType: contentType })
+
+      return fileName
+    } catch (error) {
+      throw new Error(ERROR_MESSAGES.uploadCloud)
+    }
   }
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -30,7 +30,8 @@ export class Storage {
 
     if (!firebase.apps.length) {
       this.firebase = firebase.initializeApp(
-        this.constants.CLOUD_STORAGE_CONFIG || CLOUD_STORAGE_CONFIG
+        this.constants.CLOUD_STORAGE_CONFIG || CLOUD_STORAGE_CONFIG,
+        'mintbase.js'
       )
 
       this.storage = this.firebase.storage()

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -98,15 +98,15 @@ export class Wallet {
         apiKey: walletConfig.apiKey,
         constants: this.constants,
       })
-
+      
       return this
     } catch (error) {
       return error
     }
   }
 
-  public isConnected(): boolean | undefined {
-    return this.activeWallet?.isSignedIn()
+  public isConnected(): boolean {
+    return this.activeWallet?.isSignedIn() ?? false
   }
 
   /**

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -78,18 +78,14 @@ export class Wallet {
    */
   constructor() {
     this.constants = {}
-    return this
   }
 
   public async init(walletConfig: WalletConfig): Promise<Wallet> {
-    console.log('CONFIG', walletConfig)
     try {
       this.constants = await initializeExternalConstants({
         apiKey: walletConfig.apiKey,
         networkName: this.networkName,
       })
-
-      console.log('CONSTANTS', this.constants)
 
       this.api = new API({ constants: this.constants })
 
@@ -507,7 +503,11 @@ export class Wallet {
    * @param groupId
    * @param price
    */
-  public async makeGroupOffer(groupId: string, price?: string): Promise<void> {
+  public async makeGroupOffer(
+    groupId: string,
+    price?: string,
+    marketAddress?: string
+  ): Promise<void> {
     const account = this.activeWallet?.account()
     const accountId = this.activeWallet?.account().accountId
 
@@ -525,7 +525,11 @@ export class Wallet {
 
     const contract = new Contract(
       account,
-      `0.${this.constants.FACTORY_CONTRACT_NAME || FACTORY_CONTRACT_NAME}`,
+      `0.${
+        marketAddress ||
+        this.constants.FACTORY_CONTRACT_NAME ||
+        FACTORY_CONTRACT_NAME
+      }`,
       {
         viewMethods:
           this.constants.MARKET_CONTRACT_VIEW_METHODS ||
@@ -555,7 +559,11 @@ export class Wallet {
    * @param tokenId
    * @param price
    */
-  public async makeOffer(tokenId: string, price: string): Promise<void> {
+  public async makeOffer(
+    tokenId: string,
+    price: string,
+    marketAddress?: string
+  ): Promise<void> {
     const account = this.activeWallet?.account()
     const accountId = this.activeWallet?.account().accountId
 
@@ -564,7 +572,8 @@ export class Wallet {
 
     const contract = new Contract(
       account,
-      `0.${this.constants.FACTORY_CONTRACT_NAME || FACTORY_CONTRACT_NAME}`,
+      marketAddress ||
+        `0.${this.constants.FACTORY_CONTRACT_NAME || FACTORY_CONTRACT_NAME}`,
       {
         viewMethods:
           this.constants.MARKET_CONTRACT_VIEW_METHODS ||
@@ -593,7 +602,8 @@ export class Wallet {
    * @param price
    */
   public async acceptAndTransfer(
-    tokenId: string
+    tokenId: string,
+    marketAddress?: string
   ): Promise<{ error: string | null }> {
     const account = this.activeWallet?.account()
     const accountId = this.activeWallet?.account().accountId
@@ -603,7 +613,11 @@ export class Wallet {
 
     const contract = new Contract(
       account,
-      `0.${this.constants.FACTORY_CONTRACT_NAME || FACTORY_CONTRACT_NAME}`,
+      `0.${
+        marketAddress ||
+        this.constants.FACTORY_CONTRACT_NAME ||
+        FACTORY_CONTRACT_NAME
+      }`,
       {
         viewMethods:
           this.constants.MARKET_CONTRACT_VIEW_METHODS ||
@@ -619,7 +633,8 @@ export class Wallet {
       {
         token_key: tokenId,
       },
-      MAX_GAS
+      MAX_GAS,
+      ONE_YOCTO
     )
     return {
       error: null,
@@ -630,7 +645,10 @@ export class Wallet {
    *  Withdraw the escrow deposited for an offer.
    * @param tokenKey The token key. `<tokenId>:<contractName>`
    */
-  public async withdrawOffer(tokenKey: string): Promise<void> {
+  public async withdrawOffer(
+    tokenKey: string,
+    marketAddress?: string
+  ): Promise<void> {
     const account = this.activeWallet?.account()
     const accountId = this.activeWallet?.account().accountId
 
@@ -638,7 +656,11 @@ export class Wallet {
 
     const contract = new Contract(
       account,
-      `0.${this.constants.FACTORY_CONTRACT_NAME || FACTORY_CONTRACT_NAME}`,
+      `0.${
+        marketAddress ||
+        this.constants.FACTORY_CONTRACT_NAME ||
+        FACTORY_CONTRACT_NAME
+      }`,
       {
         viewMethods:
           this.constants.MARKET_CONTRACT_VIEW_METHODS ||
@@ -1123,7 +1145,7 @@ export class Wallet {
           helperUrl: 'https://helper.testnet.near.org',
         }
 
-      case Network.main:
+      case Network.mainnet:
         return {
           networkId: 'mainnet',
           nodeUrl: 'https://rpc.mainnet.near.org',

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -84,7 +84,7 @@ export class Wallet {
     try {
       this.constants = await initializeExternalConstants({
         apiKey: walletConfig.apiKey,
-        networkName: this.networkName,
+        networkName: walletConfig.networkName || this.networkName,
       })
 
       this.api = new API({ constants: this.constants })
@@ -346,7 +346,7 @@ export class Wallet {
     tokenId: string[],
     storeId: string,
     price: string,
-    autotransfer: boolean = true
+    autotransfer = true
   ): Promise<void> {
     const account = this.activeWallet?.account()
     const accountId = this.activeWallet?.account().accountId


### PR DESCRIPTION
This PR changes fundamentally how we deal with constants. We now handle constants externally in a versioned way.

For wallet initialization, you need to `await new Wallet.init({...walletConfig})` now. This will allow valid API Key owners to fetch constants (current factory contract name and a few other constants from our backend). Once there's a response, it will pass these constants down to the API, Storage and Minter instances. 

A new class was created for Storage. This means Storage can also be initialized and used on its own. 

Tests now run on npm publishing.