### PR TITLE
♻️ Migrate thing query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mintbase",
-      "version": "0.7.0-rc.fix-exec-multiple-calls.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@types/retry": "^0.12.1",

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1152,7 +1152,7 @@ export class Wallet {
         royalties: Record<string, number>[]
       }[]
     }>(
-      `query GET_THING_BY_ID($id: String!) {
+      `query v2_getByThingId($id: String!) {
        thing: mb_views_nft_tokens(where: {metadata_id: {_eq: $id}}, limit: 1) {
           memo:mint_memo
           metaId: metadata_id

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1148,7 +1148,7 @@ export class Wallet {
         metaId: string
         storeId: string
         memo: string
-        royalties_percent: string
+        royalties_percent: number
         royalties: Record<string, number>[]
       }[]
     }>(

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1148,23 +1148,17 @@ export class Wallet {
         metaId: string
         storeId: string
         memo: string
-        tokens: {
-          royaltyPercent: string
-          royaltys: { account: string; percent: string }[]
-        }[]
+        royalties_percent: string
+        royalties: { account: string; percent: string }[]
       }[]
     }>(
       `query GET_THING_BY_ID($id: String!) {
-      thing(where: {id: {_eq: $id}}) {
-        metaId
-        storeId
-        memo
-        tokens {
-          royaltyPercent
-          royaltys {
-            account
-            percent
-          }
+       thing: mb_views_nft_tokens(where: {metadata_id: {_eq: $id}}, limit: 1) {
+          memo:mint_memo
+          metaId: metadata_id
+          storeId: nft_contract_id
+          royalties
+          royalties_percent
         }
       }
     }
@@ -1174,11 +1168,25 @@ export class Wallet {
 
     const { thing: _thing } = data
 
+    const selectedThing = _thing[0]
+
+    const thing = {
+      memo: selectedThing.memo,
+      metaId: selectedThing.metaId,
+      storeId: selectedThing.storeId,
+      tokens: [
+        {
+          royaltyPercent: selectedThing.royalties_percent,
+          royaltys: selectedThing.royalties,
+        },
+      ],
+    }
+
     if (error || _thing.length === 0) {
       return formatResponse({ error: 'Thing does not exist.' })
     }
 
-    const thing = _thing[0]
+    // const thing = _thing[0]
 
     if (thing.tokens.length === 0)
       return formatResponse({ error: 'Thing does not have tokens.' })

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1152,16 +1152,16 @@ export class Wallet {
         royalties: Record<string, number>[]
       }[]
     }>(
-      `query v2_getByThingId($id: String!) {
-       thing: mb_views_nft_tokens(where: {metadata_id: {_eq: $id}}, limit: 1) {
-          memo:mint_memo
-          metaId: metadata_id
-          storeId: nft_contract_id
-          royalties
-          royalties_percent
+      `query v2_mintbasejs_getByThingId($id: String!) {
+        thing: mb_views_nft_tokens(where: {metadata_id: {_eq: $id}}, limit: 1) {
+            memo:mint_memo
+            metaId: metadata_id
+            storeId: nft_contract_id
+            royalties
+            royalties_percent
+          }
         }
       }
-    }
     `,
       { id }
     )

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1149,7 +1149,7 @@ export class Wallet {
         storeId: string
         memo: string
         royalties_percent: string
-        royalties: { account: string; percent: string }[]
+        royalties: Record<string, number>[]
       }[]
     }>(
       `query GET_THING_BY_ID($id: String!) {
@@ -1185,8 +1185,6 @@ export class Wallet {
     if (error || _thing.length === 0) {
       return formatResponse({ error: 'Thing does not exist.' })
     }
-
-    // const thing = _thing[0]
 
     if (thing.tokens.length === 0)
       return formatResponse({ error: 'Thing does not have tokens.' })

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1161,7 +1161,6 @@ export class Wallet {
             royalties_percent
           }
         }
-      }
     `,
       { id }
     )


### PR DESCRIPTION
@microchipgnu  I see an issue on the royalties prop, the object that comes isn't the same of the old query is it?

I left the type the same as it was, but it will not have issues to the users using the wallet?

`  royalties: { account: string; percent: string }[]`