### PR TITLE
fix: error when loading page because `global` is not defined

### DIFF
--- a/packages/sdk/src/v1/constants.ts
+++ b/packages/sdk/src/v1/constants.ts
@@ -35,7 +35,9 @@ export const Network = {
 };
 
 export const NEAR_NETWORK =
-  process.env.NEAR_NETWORK || global.localStorage?.get('NEAR_NETWORK');
+  process.env.NEAR_NETWORK ||
+  globalThis?.localStorage?.get('NEAR_NETWORK') ||
+  Network.MAINNET;
 
 export const MB_MAINNET_TOKEN_FACTORY_ADDRESS = 'mintbase1.near';
 export const MB_TESTNET_TOKEN_FACTORY_ADDRESS = 'mintspace2.testnet';


### PR DESCRIPTION
![Screen Shot 2022-11-10 at 12 44 16 PM](https://user-images.githubusercontent.com/5553483/201094790-8dc529b8-bdab-4222-9c3d-12c3cc72743c.png)
