### PR TITLE
🚚 Isolate near api js in auth module

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "packages": [
     "packages/*"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -23584,9 +23584,9 @@
     },
     "packages/app": {
       "name": "mintbase-next-test-suite",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "dependencies": {
-        "@mintbase-js/sdk": "^0.0.4-alpha.1",
+        "@mintbase-js/sdk": "^0.0.4-move-near-js-exports-to-auth.0",
         "next": "12.3.1",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -24007,7 +24007,7 @@
     },
     "packages/auth": {
       "name": "@mintbase-js/auth",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/sdk": "*",
@@ -24045,7 +24045,7 @@
     },
     "packages/data": {
       "name": "@mintbase-js/data",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "license": "MIT",
       "dependencies": {
         "graphql-request": "^5.0.0"
@@ -24058,7 +24058,7 @@
     },
     "packages/react": {
       "name": "@mintbase-js/react",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/auth": "*",
@@ -24075,7 +24075,7 @@
     },
     "packages/rpc": {
       "name": "@mintbase-js/rpc",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.0.0",
@@ -24089,7 +24089,7 @@
     },
     "packages/sdk": {
       "name": "@mintbase-js/sdk",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "license": "MIT",
       "dependencies": {
         "near-api-js": "^0.44.2"
@@ -24120,7 +24120,7 @@
     },
     "packages/storage": {
       "name": "@mintbase-js/storage",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/sdk": "*",
@@ -24139,7 +24139,7 @@
     },
     "packages/testing": {
       "name": "@mintbase-js/testing",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^4.1.4",
@@ -38571,7 +38571,7 @@
     "mintbase-next-test-suite": {
       "version": "file:packages/app",
       "requires": {
-        "@mintbase-js/sdk": "^0.0.4-alpha.1",
+        "@mintbase-js/sdk": "^0.0.4-move-near-js-exports-to-auth.0",
         "@types/node": "18.7.23",
         "@types/react": "18.0.21",
         "@types/react-dom": "18.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24010,7 +24010,7 @@
       "version": "0.0.4-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@mintbase-js/sdk": "^0.0.4-alpha.1",
+        "@mintbase-js/sdk": "*",
         "@near-wallet-selector/coin98-wallet": "^7.2.0",
         "@near-wallet-selector/core": "^7.1.0",
         "@near-wallet-selector/default-wallets": "^7.2.0",
@@ -24143,9 +24143,9 @@
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^4.1.4",
+        "@mintbase-js/auth": "*",
         "@mintbase-js/sdk": "*",
-        "graphql-request": "^5.0.0",
-        "near-api-js": "^0.44.2"
+        "graphql-request": "^5.0.0"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^2.13.7",
@@ -24460,29 +24460,6 @@
     },
     "packages/testing/node_modules/mkdirp": {
       "version": "1.0.4"
-    },
-    "packages/testing/node_modules/near-api-js": {
-      "version": "0.44.2",
-      "resolved": "https://registry.npmjs.org/near-api-js/-/near-api-js-0.44.2.tgz",
-      "integrity": "sha512-eMnc4V+geggapEUa3nU2p8HSHn/njtloI4P2mceHQWO8vDE1NGpnAw8FuTBrLmXSgIv9m6oocgFc9t3VNf5zwg==",
-      "dependencies": {
-        "bn.js": "5.2.0",
-        "borsh": "^0.6.0",
-        "bs58": "^4.0.0",
-        "depd": "^2.0.0",
-        "error-polyfill": "^0.1.3",
-        "http-errors": "^1.7.2",
-        "js-sha256": "^0.9.0",
-        "mustache": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "text-encoding-utf-8": "^1.0.2",
-        "tweetnacl": "^1.0.1"
-      }
-    },
-    "packages/testing/node_modules/near-api-js/node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "packages/testing/node_modules/node-forge": {
       "version": "1.3.1"
@@ -28927,7 +28904,7 @@
     "@mintbase-js/auth": {
       "version": "file:packages/auth",
       "requires": {
-        "@mintbase-js/sdk": "^0.0.4-alpha.1",
+        "@mintbase-js/sdk": "*",
         "@near-wallet-selector/coin98-wallet": "^7.2.0",
         "@near-wallet-selector/core": "^7.1.0",
         "@near-wallet-selector/default-wallets": "^7.2.0",
@@ -29053,9 +29030,9 @@
         "@graphql-codegen/cli": "^2.13.7",
         "@graphql-codegen/client-preset": "1.1.1",
         "@graphql-codegen/introspection": "2.2.1",
+        "@mintbase-js/auth": "*",
         "@mintbase-js/sdk": "*",
-        "graphql-request": "^5.0.0",
-        "near-api-js": "^0.44.2"
+        "graphql-request": "^5.0.0"
       },
       "dependencies": {
         "@google-cloud/secret-manager": {
@@ -29373,31 +29350,6 @@
         },
         "mkdirp": {
           "version": "1.0.4"
-        },
-        "near-api-js": {
-          "version": "0.44.2",
-          "resolved": "https://registry.npmjs.org/near-api-js/-/near-api-js-0.44.2.tgz",
-          "integrity": "sha512-eMnc4V+geggapEUa3nU2p8HSHn/njtloI4P2mceHQWO8vDE1NGpnAw8FuTBrLmXSgIv9m6oocgFc9t3VNf5zwg==",
-          "requires": {
-            "bn.js": "5.2.0",
-            "borsh": "^0.6.0",
-            "bs58": "^4.0.0",
-            "depd": "^2.0.0",
-            "error-polyfill": "^0.1.3",
-            "http-errors": "^1.7.2",
-            "js-sha256": "^0.9.0",
-            "mustache": "^4.0.0",
-            "node-fetch": "^2.6.1",
-            "text-encoding-utf-8": "^1.0.2",
-            "tweetnacl": "^1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-            }
-          }
         },
         "node-forge": {
           "version": "1.3.1"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,13 +1,13 @@
 {
   "name": "mintbase-next-test-suite",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
     "lint": "eslint . --fix --ext ts --ext tsx"
   },
   "dependencies": {
-    "@mintbase-js/sdk": "^0.0.4-alpha.1",
+    "@mintbase-js/sdk": "^0.0.4-move-near-js-exports-to-auth.0",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@mintbase-js/sdk": "^0.0.4-alpha.1",
+    "@mintbase-js/sdk": "*",
     "@near-wallet-selector/coin98-wallet": "^7.2.0",
     "@near-wallet-selector/core": "^7.1.0",
     "@near-wallet-selector/default-wallets": "^7.2.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/auth",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "description": "Wallet and auth functions for Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/auth/src/account.ts
+++ b/packages/auth/src/account.ts
@@ -1,6 +1,5 @@
 
-import { connectToNear, Account } from '@mintbase-js/sdk';
-import { KeyStore } from 'near-api-js/lib/key_stores';
+import { connectToNear, Account, KeyStore } from '@mintbase-js/sdk';
 import { NearNetwork, NEAR_NETWORK, NEAR_RPC_URL } from './constants';
 
 /**

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,12 @@
 export * from './account';
 export * from './wallet';
 export * from './constants';
+
+// this is done to avoid importing near-api-js more than once
+// which leads to a strange, but known issue
+// https://docs.near.org/tools/near-api-js/faq#class-x-is-missing-in-schema-publickey
+export { Account, providers, connect as connectToNear, KeyPair } from 'near-api-js';
+export { InMemoryKeyStore, KeyStore } from 'near-api-js/lib/key_stores';
+
+// adding some other types from within libraries as a convenience
+export { FinalExecutionOutcome } from '@near-wallet-selector/core';

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/data",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "description": "Query wrappers for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/react",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "description": "React app tools for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/rpc/package-lock.json
+++ b/packages/rpc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mintbase-js/rpc",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mintbase-js/rpc",
-      "version": "0.0.4-alpha.1",
+      "version": "0.0.4-move-near-js-exports-to-auth.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.0.0",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/rpc",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "description": "NEAR RPC interactions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/sdk",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "description": "Core functions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,12 +9,3 @@ export * from './v1/token';
 export * from './v1/token.types';
 export * from './v1/market';
 export * from './v1/market.types';
-
-// this is done to avoid importing near-api-js more than once
-// which leads to a strange, but known issue
-// https://docs.near.org/tools/near-api-js/faq#class-x-is-missing-in-schema-publickey
-export { Account, providers, connect as connectToNear, KeyPair } from 'near-api-js';
-export { InMemoryKeyStore, KeyStore } from 'near-api-js/lib/key_stores';
-
-// adding some other types from within libraries as a convenience
-export { FinalExecutionOutcome } from '@near-wallet-selector/core';

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/storage",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "description": "Storage functions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@google-cloud/secret-manager": "^4.1.4",
     "@mintbase-js/sdk": "*",
-    "graphql-request": "^5.0.0",
-    "near-api-js": "^0.44.2"
+    "@mintbase-js/auth": "*",
+    "graphql-request": "^5.0.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^2.13.7",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/testing",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4-move-near-js-exports-to-auth.0",
   "description": "Integration test suite and testing utils",
   "main": "lib/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "@google-cloud/secret-manager": "^4.1.4",
-    "@mintbase-js/sdk": "*",
     "@mintbase-js/auth": "*",
+    "@mintbase-js/sdk": "*",
     "graphql-request": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/testing/src/utils.ts
+++ b/packages/testing/src/utils.ts
@@ -1,4 +1,4 @@
-import { KeyPair, InMemoryKeyStore, KeyStore  } from '@mintbase-js/sdk';
+import { KeyPair, InMemoryKeyStore, KeyStore  } from '@mintbase-js/auth';
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
 import { SECRETS_REPO_PATH } from './constants';
 

--- a/packages/testing/tests/SDK/burn.integration.test.ts
+++ b/packages/testing/tests/SDK/burn.integration.test.ts
@@ -1,11 +1,10 @@
 import { TEST_TOKEN_CONTRACT } from '../../src/constants';
 import { burn, MAX_GAS, ONE_YOCTO } from '@mintbase-js/sdk/src';
 import { execute } from '@mintbase-js/sdk/src';
-import { FinalExecutionOutcome } from '@near-wallet-selector/core';
 import { tokensByStatus } from '@mintbase-js/data/src/api/tokensByStatus/tokensByStatus';
-import { connect } from '@mintbase-js/auth';
+import { connect, FinalExecutionOutcome } from '@mintbase-js/auth';
 import { authenticatedKeyStore } from '../../src/utils';
-import { ownedTokens } from '@mintbase-js/data/lib/api/ownedTokens/ownedTokens';
+import { ownedTokens } from '@mintbase-js/data';
 
 test('burn token', async () => {
   const accounts = ['mb_alice.testnet', 'mb_bob.testnet'];
@@ -14,7 +13,7 @@ test('burn token', async () => {
   const keyStore = await authenticatedKeyStore([accountToBurnFrom]);
   const signingAccount = await connect(accountToBurnFrom, keyStore);
   const token = await ownedTokens(accountToBurnFrom, { limit: 1 });
-  
+
   if (!token) {
     throw `${accountToBurnFrom} ran out of owned tokens to burn! Mint some more...`;
   }


### PR DESCRIPTION
Fixes a super annoying borsh module.  Tried to get to the bottom of it but ultimately simply moving all references to near-api-js types and modules into our auth module exports fixed integration tests