### PR TITLE
feat(sdk): Make execute composable and return all results

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,4 +55,4 @@ jobs:
           git checkout -b ${{ github.ref_name }}
           git add --all
           git commit -m "📒 🤖 [mintbase-js] ${{ github.event.head_commit.message }}" || true
-          git push origin HEAD
+          git push origin HEAD --force

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "conventionalCommits.scopes": [
-    "sdk"
+    "sdk",
+    "doc",
+    "react"
   ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 require('dotenv').config();
+process.env.NFT_CONTRACT_ID = 'foo.near';
+// FIXME: dotenv seems to load for the jest debugger, but not when running npm test
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "packages": [
     "packages/*"
   ]

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "packages": [
     "packages/*"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -23593,9 +23593,9 @@
     },
     "packages/app": {
       "name": "mintbase-next-test-suite",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "dependencies": {
-        "@mintbase-js/sdk": "^0.0.5-docs-cleanup.1",
+        "@mintbase-js/sdk": "^0.0.5-execute-overhaul.0",
         "next": "12.3.1",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -24008,7 +24008,7 @@
     },
     "packages/auth": {
       "name": "@mintbase-js/auth",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/sdk": "*",
@@ -24046,7 +24046,7 @@
     },
     "packages/data": {
       "name": "@mintbase-js/data",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "license": "MIT",
       "dependencies": {
         "graphql-request": "^5.0.0"
@@ -24059,7 +24059,7 @@
     },
     "packages/react": {
       "name": "@mintbase-js/react",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/auth": "*",
@@ -24076,7 +24076,7 @@
     },
     "packages/rpc": {
       "name": "@mintbase-js/rpc",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.0.0",
@@ -24094,7 +24094,7 @@
     },
     "packages/sdk": {
       "name": "@mintbase-js/sdk",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "license": "MIT",
       "dependencies": {
         "near-api-js": "^0.44.2"
@@ -24125,7 +24125,7 @@
     },
     "packages/storage": {
       "name": "@mintbase-js/storage",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/sdk": "*",
@@ -24144,7 +24144,7 @@
     },
     "packages/testing": {
       "name": "@mintbase-js/testing",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^4.1.4",
@@ -38587,7 +38587,7 @@
     "mintbase-next-test-suite": {
       "version": "file:packages/app",
       "requires": {
-        "@mintbase-js/sdk": "^0.0.5-docs-cleanup.1",
+        "@mintbase-js/sdk": "^0.0.5-execute-overhaul.0",
         "@types/node": "18.7.23",
         "@types/react": "18.0.21",
         "@types/react-dom": "18.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23584,9 +23584,9 @@
     },
     "packages/app": {
       "name": "mintbase-next-test-suite",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "dependencies": {
-        "@mintbase-js/sdk": "^0.0.5-alpha.0",
+        "@mintbase-js/sdk": "^0.0.5-alpha.1",
         "next": "12.3.1",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -23999,7 +23999,7 @@
     },
     "packages/auth": {
       "name": "@mintbase-js/auth",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/sdk": "*",
@@ -24037,7 +24037,7 @@
     },
     "packages/data": {
       "name": "@mintbase-js/data",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "graphql-request": "^5.0.0"
@@ -24050,7 +24050,7 @@
     },
     "packages/react": {
       "name": "@mintbase-js/react",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/auth": "*",
@@ -24067,7 +24067,7 @@
     },
     "packages/rpc": {
       "name": "@mintbase-js/rpc",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.0.0",
@@ -24081,7 +24081,7 @@
     },
     "packages/sdk": {
       "name": "@mintbase-js/sdk",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "near-api-js": "^0.44.2"
@@ -24112,7 +24112,7 @@
     },
     "packages/storage": {
       "name": "@mintbase-js/storage",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@mintbase-js/sdk": "*",
@@ -24131,7 +24131,7 @@
     },
     "packages/testing": {
       "name": "@mintbase-js/testing",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^4.1.4",
@@ -38563,7 +38563,7 @@
     "mintbase-next-test-suite": {
       "version": "file:packages/app",
       "requires": {
-        "@mintbase-js/sdk": "^0.0.5-alpha.0",
+        "@mintbase-js/sdk": "^0.0.5-alpha.1",
         "@types/node": "18.7.23",
         "@types/react": "18.0.21",
         "@types/react-dom": "18.0.6",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,13 +1,13 @@
 {
   "name": "mintbase-next-test-suite",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
     "lint": "eslint . --fix --ext ts --ext tsx"
   },
   "dependencies": {
-    "@mintbase-js/sdk": "^0.0.5-docs-cleanup.1",
+    "@mintbase-js/sdk": "^0.0.5-execute-overhaul.0",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,13 +1,13 @@
 {
   "name": "mintbase-next-test-suite",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "private": true,
   "scripts": {
     "dev": "next dev",
     "lint": "eslint . --fix --ext ts --ext tsx"
   },
   "dependencies": {
-    "@mintbase-js/sdk": "^0.0.5-alpha.0",
+    "@mintbase-js/sdk": "^0.0.5-alpha.1",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/auth",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "description": "Wallet and auth functions for Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/auth",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "description": "Wallet and auth functions for Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/data",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "description": "Query wrappers for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/data",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "description": "Query wrappers for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/react",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "description": "React app tools for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/react",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "description": "React app tools for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react/src/hooks/useMinter.ts
+++ b/packages/react/src/hooks/useMinter.ts
@@ -26,18 +26,14 @@ export const useMinter = (args: MintArgs): MinterHookReturn => {
     // TODO: use @mintbase/storage to get a reference
     const reference = '';
 
-    await execute(
-      {
-        ...mint({
-          nftContractId,
-          metadata: {
-            reference: reference,
-          },
-          options,
-        }),
-        signerId: activeAccountId,
-      },
-      { wallet: await selector.wallet() },
+    await execute({ wallet: await selector.wallet() },
+      mint({
+        nftContractId,
+        metadata: {
+          reference: reference,
+        },
+        options,
+      }),
     );
 
     setLoading(false);

--- a/packages/rpc/package-lock.json
+++ b/packages/rpc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mintbase-js/rpc",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mintbase-js/rpc",
-      "version": "0.0.5-docs-cleanup.1",
+      "version": "0.0.5-execute-overhaul.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.0.0",

--- a/packages/rpc/package-lock.json
+++ b/packages/rpc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mintbase-js/rpc",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mintbase-js/rpc",
-      "version": "0.0.5-alpha.0",
+      "version": "0.0.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.0.0",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/rpc",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "description": "NEAR RPC interactions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/rpc",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "description": "NEAR RPC interactions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/sdk",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "description": "Core functions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/sdk",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "description": "Core functions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/sdk/src/buy/buy.test.ts
+++ b/packages/sdk/src/buy/buy.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { GAS, MARKET_METHOD_NAMES, MB_TESTNET_MARKET_CONTRACT_ADDRESS } from '../constants';
+import { GAS, MARKET_METHOD_NAMES, MB_MARKET_ADDRESS } from '../constants';
 import { buy } from './buy';
 
 
@@ -17,7 +17,7 @@ test('buy a token', () => {
   });
 
   expect(args).toEqual({
-    contractAddress: MB_TESTNET_MARKET_CONTRACT_ADDRESS,
+    contractAddress: MB_MARKET_ADDRESS,
     methodName: MARKET_METHOD_NAMES.BUY,
     args: {
       nft_contract_id: nftContractId,

--- a/packages/sdk/src/buy/buy.ts
+++ b/packages/sdk/src/buy/buy.ts
@@ -16,14 +16,14 @@ export type BuyArgs = {
  * Buys a listed token for a specified price as long as its above the price for which is was listed
  * @param buyArguments {@link BuyArgs}
  * @returns contract call to be passed to @mintbase-js/sdk execute method
- */  
+ */
 export const buy = (args: BuyArgs): NearContractCall => {
   const { nftContractId = DEFAULT_CONTRACT_ADDRESS, tokenId, referrerId = null, marketId = MB_MARKET_ADDRESS, price } = args;
 
   if (nftContractId == null) {
-    throw new Error('You must provide a nftContractId or define a NFT_CONTRACT_ID enviroment variable to default to');
+    throw new Error('You must provide a nftContractId or define a NFT_CONTRACT_ID environment variable to default to');
   }
-  
+
   return {
     contractAddress: marketId,
     args: {

--- a/packages/sdk/src/deployContract/deployContract.test.ts
+++ b/packages/sdk/src/deployContract/deployContract.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { CONTRACT_DEPOSIT, DEFAULT_MB_LOGO, GAS_CONSTANTS, MB_TESTNET_TOKEN_FACTORY_ADDRESS, TOKEN_METHOD_NAMES } from '../constants';
+import { CONTRACT_DEPOSIT, DEFAULT_MB_LOGO, GAS_CONSTANTS, MB_TOKEN_FACTORY_ADDRESS, TOKEN_METHOD_NAMES } from '../constants';
 import { deployContract } from './deployContract';
 
 test('deploy contract set all values', () => {
@@ -77,7 +77,7 @@ test('deploy contract standardizing name and symbol to remove unwanted character
     gas: GAS_CONSTANTS.DEFAULT_GAS,
     deposit: CONTRACT_DEPOSIT,
   });
-    
+
 
 });
 
@@ -92,11 +92,11 @@ test('deploy contract uses default values', () => {
     ownerId: 'test',
     metadata: mockMetadata,
   };
-  
+
   const result = deployContract(mockData);
-  
+
   expect(result).toEqual({
-    contractAddress: MB_TESTNET_TOKEN_FACTORY_ADDRESS,
+    contractAddress: MB_TOKEN_FACTORY_ADDRESS,
     methodName: TOKEN_METHOD_NAMES.DEPLOY_TOKEN_CONTRACT,
     args: {
       owner_id: mockData.ownerId,
@@ -113,6 +113,6 @@ test('deploy contract uses default values', () => {
     gas: GAS_CONSTANTS.DEFAULT_GAS,
     deposit: CONTRACT_DEPOSIT,
   });
-      
-  
+
+
 });

--- a/packages/sdk/src/deployContract/deployContract.ts
+++ b/packages/sdk/src/deployContract/deployContract.ts
@@ -12,7 +12,7 @@ export type DeployContractArgs = {
       icon?: string;
       baseUri?: string;
       reference?: string;
-      referenceHash?: string; 
+      referenceHash?: string;
     };
   };
 
@@ -23,9 +23,9 @@ export type DeployContractArgs = {
  */
 export const deployContract = (args: DeployContractArgs): NearContractCall=> {
   const { name, factoryContractId = MB_TOKEN_FACTORY_ADDRESS, ownerId, metadata } = args;
-  
+
   const { symbol, icon = DEFAULT_MB_LOGO, baseUri = null, reference = null, referenceHash = null } = metadata;
-  
+
   return {
     contractAddress: factoryContractId,
     methodName: TOKEN_METHOD_NAMES.DEPLOY_TOKEN_CONTRACT,

--- a/packages/sdk/src/execute.test.ts
+++ b/packages/sdk/src/execute.test.ts
@@ -13,9 +13,9 @@ describe('contract method calls (execute)', () => {
   const testMethod = 'nft_transfer';
   const testCallbackUrl = 'ftp://mintbase.testnet';
   const testArgs = {
-    // eslint-disable-next-line @typescript-eslint/camelcase
+
     token_id: 'fake.token.id',
-    // eslint-disable-next-line @typescript-eslint/camelcase
+
     receiver_id: 'mb_bob.testnet',
   };
   const testContractCall: NearContractCall = {
@@ -38,24 +38,25 @@ describe('contract method calls (execute)', () => {
   };
 
   beforeAll(() => {
-    jest.spyOn(global.console, 'error').mockImplementation(() => null);
+    jest.spyOn(global.console, 'error');
   });
 
-  afterEach(() => jest.resetAllMocks());
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
   test('execute should throw without a valid signing method ', () => {
-    expect(execute(testContractCall, {}))
+    expect(execute({}, testContractCall ))
       .rejects
       .toThrow(NoSigningMethodPassedError);
   });
 
   test('execute calls through to browser wallet selector method', async () => {
     await execute(
-      testContractCall,
       {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         wallet: mockNearSelectorWallet as any,
       },
+      testContractCall,
     );
 
     const expectedCallArgs: BrowserWalletSignAndSendTransactionParams = {
@@ -78,11 +79,10 @@ describe('contract method calls (execute)', () => {
 
   test('passing multiple calls invokes batch execute', async () => {
     await execute(
-      [testContractCall, testContractCall],
       {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         wallet: mockNearSelectorWallet as any,
       },
+      [testContractCall, testContractCall], testContractCall,
     );
 
     expect(
@@ -97,9 +97,9 @@ describe('contract method calls (execute)', () => {
 
   test('execute calls through to account (near api) method', async () => {
     await execute(
-      testContractCall,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { account: mockNearAccount as any },
+      testContractCall,
+      
     );
 
     const expectedCallArgs: FunctionCallOptions = {
@@ -116,23 +116,23 @@ describe('contract method calls (execute)', () => {
 
   test('multiple calls batch executes with account', async () => {
     await execute(
-      [testContractCall, testContractCall],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       { account: mockNearAccount as any },
+      testContractCall, testContractCall, [testContractCall], [testContractCall, testContractCall],
+      
     );
 
-    expect(mockNearAccount.functionCall).toBeCalledTimes(2);
+    expect(mockNearAccount.functionCall).toBeCalledTimes(5);
   });
 
-  test('should warn in multiple call failure situation', async () => {
-    mockNearAccount.functionCall.mockRejectedValue('thud');
-    await execute(
-      [testContractCall, testContractCall],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { account: mockNearAccount as any },
-    );
-    expect(console.error).toBeCalledTimes(2);
-  });
+  // test('should warn in multiple call failure situation', async () => {
+  //   mockNearAccount.functionCall.mockRejectedValue('thud');
+  //   await execute(
+  //     { account: mockNearAccount as any },
+  //     [testContractCall, testContractCall], testContractCall,
+      
+  //   );
+  //   expect(console.error).toBeCalledTimes(3);
+  // });
 
   // TODO:
   //  - more signing options?

--- a/packages/sdk/src/execute.test.ts
+++ b/packages/sdk/src/execute.test.ts
@@ -1,11 +1,7 @@
-import {
-  BrowserWalletSignAndSendTransactionParams,
-} from '@near-wallet-selector/core/lib/wallet';
-import { FunctionCallOptions } from 'near-api-js/lib/account';
 import { execute, NearContractCall } from './execute';
-
 import { MAX_GAS, ONE_YOCTO } from './constants';
 import { NoSigningMethodPassedError } from './errors';
+import BN from 'bn.js';
 
 describe('contract method calls (execute)', () => {
   const testSigner = 'mb_alice.testnet';
@@ -63,7 +59,7 @@ describe('contract method calls (execute)', () => {
       actions:[{
         params: {
           args: testArgs,
-          methodName: testMethod,         
+          methodName: testMethod,
           gas: MAX_GAS,
           deposit: ONE_YOCTO,
         },
@@ -101,15 +97,15 @@ describe('contract method calls (execute)', () => {
     await execute(
       { account: mockNearAccount as any },
       testContractCall,
-      
+
     );
 
     const expectedCallArgs = {
       contractId: testContract,
       methodName: testMethod,
       args: testArgs,
-      gas: MAX_GAS,
-      attachedDeposit: ONE_YOCTO,
+      gas: new BN(MAX_GAS),
+      attachedDeposit: new BN(ONE_YOCTO),
 
     };
     expect(mockNearAccount.functionCall)
@@ -120,7 +116,7 @@ describe('contract method calls (execute)', () => {
     await execute(
       { account: mockNearAccount as any },
       testContractCall, testContractCall, [testContractCall], [testContractCall, testContractCall],
-      
+
     );
 
     expect(mockNearAccount.functionCall).toBeCalledTimes(5);
@@ -131,7 +127,7 @@ describe('contract method calls (execute)', () => {
     await execute(
       { account: mockNearAccount as any },
       [testContractCall, testContractCall], testContractCall,
-      
+
     );
     expect(console.error).toBeCalledTimes(3);
   });

--- a/packages/sdk/src/execute.ts
+++ b/packages/sdk/src/execute.ts
@@ -29,11 +29,10 @@ const validateSigningOptions = ({ wallet, account }: NearCallSigningOptions): vo
 
 /**
  * Base method for executing contract calls.
- *
- * @param call an array or single instance of {@link NearContractCall} to execute
  * @param signing object containing either near wallet selector
+ * @param calls  {@link NearContractCall[]} any number of of single calls or compositions
  *  wallet: {@link Wallet} or account: {@link Account}, defaults to wallet when present
- * @returns a result for single transactions of {@link FinalExecutionOutcome}, or void for batches
+ * @returns an outcome object or an array of outcome objects if batching calls {@link FinalExecutionOutcome[]} | {@link FinalExecutionOutcome}
  */
 export const execute = async (
   { wallet, account }: NearCallSigningOptions,

--- a/packages/sdk/src/execute.ts
+++ b/packages/sdk/src/execute.ts
@@ -71,8 +71,8 @@ const batchExecuteWithNearAccount = async (
         contractId: call.contractAddress,
         methodName: call.methodName,
         args: call.args,
-        gas: call.gas,
-        attachedDeposit: call.deposit,
+        gas: call.gas as string,
+        attachedDeposit: call.deposit as string,
       }));
     } catch (err: unknown) {
       console.error(

--- a/packages/sdk/src/execute.ts
+++ b/packages/sdk/src/execute.ts
@@ -4,21 +4,14 @@ import { BrowserWalletSignAndSendTransactionParams } from '@near-wallet-selector
 import type { providers, Account } from 'near-api-js';
 import { NoSigningMethodPassedError } from './errors';
 
-export type TransactionArgs = {
+export type ContractCall = {
   contractAddress: string;
   methodName: string;
   args: object;
-};
-
-export type TransactionAttachments = {
   gas: string;
   deposit: string;
-};
-
-export type ContractCall = TransactionArgs &
-  TransactionAttachments & {
-    signerId?: string;
-    callbackUrl?: string;
+  signerId?: string;
+  callbackUrl?: string;
   };
 
 export type NearContractCall = ContractCall | ContractCall[]
@@ -45,19 +38,18 @@ const validateSigningOptions = ({ wallet, account }: NearCallSigningOptions): vo
 export const execute = async (
   { wallet, account }: NearCallSigningOptions,
   ...calls: NearContractCall[]
-): Promise<void | providers.FinalExecutionOutcome> => {
+): Promise<void | providers.FinalExecutionOutcome | providers.FinalExecutionOutcome[] > => {
   validateSigningOptions({ wallet, account });
-
-  for (const call of calls) {
-    if (call instanceof Array && call.length > 0) {
-      await genericBatchExecute(call as ContractCall[], wallet, account);
-    }
-    await genericExecute(call as ContractCall, wallet, account);
+  
+  const outcomes = await genericBatchExecute(flattenArgs(calls), wallet, account);
+  if (outcomes && outcomes.length == 1) {
+    return outcomes[0];    
   }
+  return outcomes;
 
 };
 
-const genericBatchExecute = async (call: ContractCall[], wallet: Wallet, account: Account): Promise<void | providers.FinalExecutionOutcome> =>{
+const genericBatchExecute = async (call: ContractCall[], wallet: Wallet, account: Account): Promise<void | providers.FinalExecutionOutcome[]> =>{
   if (wallet) {
     return batchExecuteWithBrowserWallet(call, wallet);
   }
@@ -65,67 +57,37 @@ const genericBatchExecute = async (call: ContractCall[], wallet: Wallet, account
  
 };
 
-const genericExecute = async (call: ContractCall, wallet: Wallet, account: Account): Promise<void | providers.FinalExecutionOutcome> =>{
-  if (wallet) {
-    return executeWithBrowserWallet(call, wallet);
-  }
-  return executeWithNearAccount(call, account);
-};
-
-
-////////////  NEAR ACCOUNT METHODS ////////////
-
-// account call translation wrappers
+// account call translation wrappers https://docs.near.org/tools/near-api-js/faq#how-to-send-batch-transactions
 // TODO: share batch signature with wallet selector sendAndSignTransaction when method becomes public
-// https://docs.near.org/tools/near-api-js/faq#how-to-send-batch-transactions
-
-const executeWithNearAccount = async (
-  call: ContractCall,
-  account: Account,
-): Promise<void | providers.FinalExecutionOutcome> => account.functionCall({
-  contractId: call.contractAddress,
-  methodName: call.methodName,
-  args: call.args,
-  gas: call.gas,
-  attachedDeposit: call.deposit,
-});
-
 
 const batchExecuteWithNearAccount = async (
   calls: ContractCall[],
   account: Account,
-): Promise<void> => {
+): Promise<FinalExecutionOutcome[]> => {
+  const outcomes: FinalExecutionOutcome[] =[];
   for (const call of calls) {
     try {
-      await account.functionCall({
+      outcomes.push(await account.functionCall({
         contractId: call.contractAddress,
         methodName: call.methodName,
         args: call.args,
         gas: call.gas,
         attachedDeposit: call.deposit,
-      });
+      }));
     } catch (err: unknown) {
       console.error(
         `${call.contractAddress}:${call.methodName} in batch failed: ${err}`,
       );
     }
   }
+  return outcomes;
 };
-
-
-////////////  BROWSER WALLET METHODS ////////////
-
-const executeWithBrowserWallet = async (
-  call: ContractCall,
-  wallet: Wallet,
-): Promise<void | providers.FinalExecutionOutcome> =>
-  wallet.signAndSendTransaction(convertGenericCallToWalletCall(call));
 
 const batchExecuteWithBrowserWallet = async (
   calls: ContractCall[],
   wallet: Wallet,
-): Promise<void> => {
-  await wallet.signAndSendTransactions({
+): Promise<void | FinalExecutionOutcome[]> => {
+  return await wallet.signAndSendTransactions({
     transactions: calls.map(convertGenericCallToWalletCall) as TxnOptionalSignerId[],
   });
 };
@@ -150,5 +112,17 @@ const convertGenericCallToWalletCall = (
     },
   }],
 });
+
+function flattenArgs(calls: NearContractCall[]): ContractCall[] {
+  const contractCalls: ContractCall[] =[];
+  for (const call of calls) {
+    if (call instanceof Array && call.length > 0 && call as ContractCall[]) {
+      call.map(item => contractCalls.push(item as ContractCall));
+    } else {
+      contractCalls.push(call as ContractCall);
+    }
+  }
+  return contractCalls;
+}
 
 

--- a/packages/sdk/src/execute.ts
+++ b/packages/sdk/src/execute.ts
@@ -40,10 +40,10 @@ export const execute = async (
   ...calls: NearContractCall[]
 ): Promise<void | providers.FinalExecutionOutcome | providers.FinalExecutionOutcome[] > => {
   validateSigningOptions({ wallet, account });
-  
+
   const outcomes = await genericBatchExecute(flattenArgs(calls), wallet, account);
   if (outcomes && outcomes.length == 1) {
-    return outcomes[0];    
+    return outcomes[0];
   }
   return outcomes;
 
@@ -54,7 +54,7 @@ const genericBatchExecute = async (call: ContractCall[], wallet: Wallet, account
     return batchExecuteWithBrowserWallet(call, wallet);
   }
   return batchExecuteWithNearAccount(call, account);
- 
+
 };
 
 // account call translation wrappers https://docs.near.org/tools/near-api-js/faq#how-to-send-batch-transactions
@@ -71,8 +71,8 @@ const batchExecuteWithNearAccount = async (
         contractId: call.contractAddress,
         methodName: call.methodName,
         args: call.args,
-        gas: call.gas as string,
-        attachedDeposit: call.deposit as string,
+        gas: new BN(call.gas),
+        attachedDeposit: new BN(call.deposit),
       }));
     } catch (err: unknown) {
       console.error(

--- a/packages/sdk/src/mint/README.md
+++ b/packages/sdk/src/mint/README.md
@@ -33,20 +33,20 @@ export type MintArgs =  {
 
 export type MintOptions = {
     // 0 < royaltyPercentage < 0.5
-    //total percentage that will be allocated to royalties. 
+    //total percentage that will be allocated to royalties.
     //the maximum amount that can be allocated to royalties is 0.5 (50%)
-    //this value cant be negative   
+    //this value cant be negative
     royaltyPercentage?: number;
     //key value pairs of ids and the relative percentage of the allocated royalties amount
     //splits must have at least 2 entries
     //splits must not have more than 50 entries
-    //the splits percentage amounts must total to 1 meaning 100% of royaltyPercentage 
+    //the splits percentage amounts must total to 1 meaning 100% of royaltyPercentage
     //i.e royaltyPercentage = 0.3 splits = {test1: 0.5, test2: 0.5}
     //in this case test1 and test2 will receive 0.15 of the total gains (0.5*0.3)
     splits?: Splits;
     //the amount of copies of specified token to be minted
     //this amount cannot be larger than 99
-    amount?: number;    
+    amount?: number;
 }
 ```
 

--- a/packages/sdk/src/transfer/transfer.test.ts
+++ b/packages/sdk/src/transfer/transfer.test.ts
@@ -1,5 +1,6 @@
 import { transfer, DEPOSIT_FOR_TRANSFER, GAS_FOR_TRANSFER } from './transfer';
 import { DEFAULT_CONTRACT_ADDRESS, TOKEN_METHOD_NAMES } from '../constants';
+import { ContractCall } from '../execute';
 
 describe('transfer token unit tests', () => {
   const nftContractId = 'test.nft.contract';
@@ -30,7 +31,7 @@ describe('transfer token unit tests', () => {
   test('uses contract from env', () => {
     const transferCall = transfer({
       transfers: [{ receiverId: receiverId, tokenId: tokenId1 }],
-    });
+    }) as ContractCall;
     expect(transferCall.contractAddress).toBe(DEFAULT_CONTRACT_ADDRESS);
   });
 

--- a/packages/sdk/src/transfer/transfer.ts
+++ b/packages/sdk/src/transfer/transfer.ts
@@ -24,8 +24,8 @@ export const transfer = ({
   transfers,
   nftContractId = DEFAULT_CONTRACT_ADDRESS,
 }: TransferArgs): NearContractCall => {
-  if (nftContractId == null) {
-    throw new Error('You must provide a nftContractId or define a NFT_CONTRACT_ID env to default to');
+  if (nftContractId === null) {
+    throw new Error('You must provide a nftContractId or define a NFT_CONTRACT_ID env as default');
   }
 
   if (transfer.length == 0) {
@@ -40,7 +40,7 @@ export const transfer = ({
     return {
       contractAddress: nftContractId,
       methodName: TOKEN_METHOD_NAMES.BATCH_TRANSFER,
-      args: {     
+      args: {
         token_ids: ids,
       },
       deposit: DEPOSIT_FOR_TRANSFER,
@@ -52,7 +52,7 @@ export const transfer = ({
     return {
       contractAddress: nftContractId,
       methodName: TOKEN_METHOD_NAMES.TRANSFER,
-      args: {   
+      args: {
         receiver_id: receiverId,
         token_id: tokenId,
       },

--- a/packages/sdk/src/v1/market.ts
+++ b/packages/sdk/src/v1/market.ts
@@ -1,7 +1,7 @@
 // Mintbase marketplace contract JS implementation
 
 import { utils } from 'near-api-js';
-import { TransactionArgs, TransactionAttachments } from '../execute';
+import { NearContractCall } from '../execute';
 import {
   DEPOSIT_CONSTANTS,
   GAS_CONSTANTS,
@@ -11,7 +11,7 @@ import { BuyArgs, DepositStorageArgs, ListArgs } from './market.types';
 
 export const buy = (
   args: BuyArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { nftContractId, tokenId, referrerId, marketAddress, price } = args;
   return {
     contractAddress: marketAddress,
@@ -31,7 +31,7 @@ export const buy = (
 
 export const list = (
   args: ListArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { nftContractId, tokenId, approvedAccountId, price } = args;
 
   return {
@@ -53,7 +53,7 @@ export const list = (
 
 export const depositStorage = (
   args: DepositStorageArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { marketAddress, listAmount = 1 } = args;
 
   const deposit = (0.01 * listAmount).toString();

--- a/packages/sdk/src/v1/token.ts
+++ b/packages/sdk/src/v1/token.ts
@@ -1,6 +1,5 @@
 // Mintbase token contract JS implementation
 
-import { TransactionArgs, TransactionAttachments } from '../execute';
 import {
   DEFAULT_MB_LOGO,
   TOKEN_METHOD_NAMES,
@@ -9,6 +8,7 @@ import {
   GAS_CONSTANTS,
   DEPOSIT_CONSTANTS,
 } from '../constants';
+import { NearContractCall } from '../execute';
 import {
   BurnArgs,
   DeployTokenContractArgs,
@@ -23,7 +23,7 @@ import {
 
 export const burn = (
   args: BurnArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { nftContractId, tokenIds } = args;
 
   return {
@@ -40,7 +40,7 @@ export const burn = (
 
 export const deployContract = (
   args: DeployTokenContractArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const {
     name,
     factoryContractId,
@@ -78,7 +78,7 @@ export const deployContract = (
 
 export const transferContractOwnership = (
   args: TransferTokenContractOwnership,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { nftContractId, nextOwner, options } = args;
   const { keepMinters = true } = options;
 
@@ -98,7 +98,7 @@ export const transferContractOwnership = (
 
 export const mint = (
   args: MintArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { nftContractId, options } = args;
 
   return {
@@ -117,7 +117,7 @@ export const mintMore = (): void => {
 
 export const addMinter = (
   args: AddRemoveMinterArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { minterId, nftContractId } = args;
 
   return {
@@ -134,7 +134,7 @@ export const addMinter = (
 
 export const removeMinter = (
   args: AddRemoveMinterArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { minterId, nftContractId } = args;
 
   return {
@@ -151,7 +151,7 @@ export const removeMinter = (
 
 export const batchChangeMinters = (
   args: BatchChangeMinters,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { addMinters, removeMinters, nftContractId } = args;
 
   return {
@@ -168,7 +168,7 @@ export const batchChangeMinters = (
 
 export const revoke = (
   args: RevokeAccountArgs,
-): TransactionArgs & TransactionAttachments => {
+): NearContractCall => {
   const { nftContractId, tokenId, accountToRevokeId } = args;
 
   if (accountToRevokeId) {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/storage",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "description": "Storage functions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/storage",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "description": "Storage functions for  Mintbase JS SDK",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/testing",
-  "version": "0.0.5-alpha.0",
+  "version": "0.0.5-alpha.1",
   "description": "Integration test suite and testing utils",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintbase-js/testing",
-  "version": "0.0.5-docs-cleanup.1",
+  "version": "0.0.5-execute-overhaul.0",
   "description": "Integration test suite and testing utils",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/testing/tests/SDK/addRemoveMinter.integration.test.ts
+++ b/packages/testing/tests/SDK/addRemoveMinter.integration.test.ts
@@ -1,7 +1,7 @@
 import { addMinter } from '@mintbase-js/sdk/src/addMinter/addMinter';
 import { removeMinter } from '@mintbase-js/sdk/src/removeMinter/removeMinter';
 import { execute } from '@mintbase-js/sdk/src';
-import { connect } from '@mintbase-js/auth';
+import { connect, FinalExecutionOutcome } from '@mintbase-js/auth';
 import { authenticatedKeyStore } from '../../src/utils';
 
 test('add and remove minter integration test', async () => {
@@ -22,9 +22,12 @@ test('add and remove minter integration test', async () => {
     minterId: minterId,
   });
 
-  await execute(
+  const result = await execute(
     { account: signingAccount },
     add, remove,
-  );
+  ) as FinalExecutionOutcome[];
+
+  expect(result[0].receipts_outcome).not.toBeUndefined();
+  expect(result[1].receipts_outcome).not.toBeUndefined();
 });
 

--- a/packages/testing/tests/SDK/addRemoveMinter.integration.test.ts
+++ b/packages/testing/tests/SDK/addRemoveMinter.integration.test.ts
@@ -23,8 +23,8 @@ test('add and remove minter integration test', async () => {
   });
 
   await execute(
-    [add, remove],
     { account: signingAccount },
+    add, remove,
   );
 });
 

--- a/packages/testing/tests/SDK/batchChangeMinters.integration.test.ts
+++ b/packages/testing/tests/SDK/batchChangeMinters.integration.test.ts
@@ -1,6 +1,6 @@
 import { batchChangeMinters } from '../../../sdk/src/batchChangeMinters/batchChangeMinters';
 import { execute } from '@mintbase-js/sdk/src';
-import { connect } from '@mintbase-js/auth';
+import { connect, FinalExecutionOutcome } from '@mintbase-js/auth';
 import { authenticatedKeyStore } from '../../src/utils';
 
 test('batch change minters integration test', async () => {
@@ -21,8 +21,11 @@ test('batch change minters integration test', async () => {
     removeMinters: minterIds,
   });
 
-  await execute(
+  const result = await execute(
     { account: signingAccount },
     add, remove,
-  );
+  ) as FinalExecutionOutcome[];
+
+  expect(result[0].receipts_outcome).not.toBeUndefined();
+  expect(result[1].receipts_outcome).not.toBeUndefined();
 });

--- a/packages/testing/tests/SDK/batchChangeMinters.integration.test.ts
+++ b/packages/testing/tests/SDK/batchChangeMinters.integration.test.ts
@@ -22,7 +22,7 @@ test('batch change minters integration test', async () => {
   });
 
   await execute(
-    [add, remove],
     { account: signingAccount },
+    add, remove,
   );
 });

--- a/packages/testing/tests/SDK/burn.integration.test.ts
+++ b/packages/testing/tests/SDK/burn.integration.test.ts
@@ -35,12 +35,11 @@ test('burn token', async () => {
   }
 
   const result = (await execute(  
+    { account: signingAccount },
     burn({
       nftContractId: TEST_TOKEN_CONTRACT,
       tokenIds: tokenToBurn,
     }),
-    { account: signingAccount },
-  )) as FinalExecutionOutcome;
+  ));
 
-  expect(result.receipts_outcome).not.toBeUndefined();
 });

--- a/packages/testing/tests/SDK/burn.integration.test.ts
+++ b/packages/testing/tests/SDK/burn.integration.test.ts
@@ -40,6 +40,8 @@ test('burn token', async () => {
       nftContractId: TEST_TOKEN_CONTRACT,
       tokenIds: tokenToBurn,
     }),
-  ));
+  )) as FinalExecutionOutcome;
+
+  expect(result.receipts_outcome).not.toBeUndefined();
 
 });

--- a/packages/testing/tests/SDK/buy.integration.test.ts
+++ b/packages/testing/tests/SDK/buy.integration.test.ts
@@ -31,12 +31,12 @@ test('buy a token', async () => {
  
 
   const result = (await execute(
+    { account: signingAccount },
     buy({
       nftContractId: TEST_TOKEN_CONTRACT,
       price: '1',
       tokenId: tokenToBuy,
     }),
-    { account: signingAccount },
   )) as FinalExecutionOutcome;
 
   expect(result.receipts_outcome).not.toBeUndefined();

--- a/packages/testing/tests/SDK/deployContract.integration.test.ts
+++ b/packages/testing/tests/SDK/deployContract.integration.test.ts
@@ -11,6 +11,7 @@ test('deploy contract', async () => {
 
 
   const result = (await execute(
+    { account: signingAccount },
     deployContract({
       name: makeRandomString(10),
       ownerId: account,
@@ -18,7 +19,6 @@ test('deploy contract', async () => {
         symbol: 'test',
       },
     }),
-    { account: signingAccount },
   )) as FinalExecutionOutcome;
 
   expect(result.receipts_outcome).not.toBeUndefined();

--- a/packages/testing/tests/SDK/deposit.integration.test.ts
+++ b/packages/testing/tests/SDK/deposit.integration.test.ts
@@ -11,10 +11,9 @@ test('deposit storage for current account', async () => {
   const signingAccount = await connect(accountToDepositFrom, keyStore);
 
   const result = (await execute(
-    {
-      ...depositStorage({}),
-    },
+  
     { account: signingAccount },
+    depositStorage({}),
   )) as FinalExecutionOutcome; 
 
 

--- a/packages/testing/tests/SDK/list.integration.test.ts
+++ b/packages/testing/tests/SDK/list.integration.test.ts
@@ -39,12 +39,12 @@ test('list a token', async () => {
   }
 
   const result = (await execute(
+    { account: signingAccount },
     list({
       nftContractId: TEST_TOKEN_CONTRACT,
       tokenId: tokenToList,
       price: '1',
     }),
-    { account: signingAccount },
   )) as FinalExecutionOutcome;
 
   expect(result.receipts_outcome).not.toBeUndefined();

--- a/packages/testing/tests/SDK/mint.integration.test.ts
+++ b/packages/testing/tests/SDK/mint.integration.test.ts
@@ -10,16 +10,12 @@ test('mint token without options', async () => {
   const signingAccount = await connect('mb_alice.testnet', keyStore);
   
   const result = (await execute(
-    {
-      ...mint({
-        nftContractId: TEST_TOKEN_CONTRACT,
-        ownerId: 'mb_bob.testnet',
-        reference: 'https://arweave.net/OzOg7k329BMjb-ib3AZ3cCrxf5KpChzyBAobHtulxRE',
-      }),
-      gas: GAS,
-      deposit: ONE_YOCTO,
-    },
     { account: signingAccount },
+    mint({
+      nftContractId: TEST_TOKEN_CONTRACT,
+      ownerId: 'mb_bob.testnet',
+      reference: 'https://arweave.net/OzOg7k329BMjb-ib3AZ3cCrxf5KpChzyBAobHtulxRE',
+    }),
   )) as FinalExecutionOutcome;
   
   expect(result.receipts_outcome).not.toBeUndefined();
@@ -32,24 +28,20 @@ test('mint token with options', async () => {
   const signingAccount = await connect('mb_alice.testnet', keyStore);
     
   const result = (await execute(
-    {
-      ...mint({
-        nftContractId: TEST_TOKEN_CONTRACT,
-        ownerId: 'mb_bob.testnet',
-        reference: 'https://arweave.net/OzOg7k329BMjb-ib3AZ3cCrxf5KpChzyBAobHtulxRE',
-        options: {
-          royaltyPercentage: 0.5,
-          splits: {
-            'test1': 0.5,
-            'test': 0.5,
-          },
-          amount: 2,
-        },
-      }),
-      gas: GAS,
-      deposit: ONE_YOCTO,
-    },
     { account: signingAccount },
+    mint({
+      nftContractId: TEST_TOKEN_CONTRACT,
+      ownerId: 'mb_bob.testnet',
+      reference: 'https://arweave.net/OzOg7k329BMjb-ib3AZ3cCrxf5KpChzyBAobHtulxRE',
+      options: {
+        royaltyPercentage: 0.5,
+        splits: {
+          'test1': 0.5,
+          'test': 0.5,
+        },
+        amount: 2,
+      },
+    }),
   )) as FinalExecutionOutcome;
     
   expect(result.receipts_outcome).not.toBeUndefined();

--- a/packages/testing/tests/SDK/mint.integration.test.ts
+++ b/packages/testing/tests/SDK/mint.integration.test.ts
@@ -26,25 +26,28 @@ test('mint token with options', async () => {
 
   const keyStore = await authenticatedKeyStore(['mb_alice.testnet']);
   const signingAccount = await connect('mb_alice.testnet', keyStore);
+
+  const mintCall = mint({
+    nftContractId: TEST_TOKEN_CONTRACT,
+    ownerId: 'mb_bob.testnet',
+    reference: 'https://arweave.net/OzOg7k329BMjb-ib3AZ3cCrxf5KpChzyBAobHtulxRE',
+    options: {
+      royaltyPercentage: 0.5,
+      splits: {
+        'test1': 0.5,
+        'test': 0.5,
+      },
+      amount: 1,
+    },
+  });
     
   const result = (await execute(
     { account: signingAccount },
-    mint({
-      nftContractId: TEST_TOKEN_CONTRACT,
-      ownerId: 'mb_bob.testnet',
-      reference: 'https://arweave.net/OzOg7k329BMjb-ib3AZ3cCrxf5KpChzyBAobHtulxRE',
-      options: {
-        royaltyPercentage: 0.5,
-        splits: {
-          'test1': 0.5,
-          'test': 0.5,
-        },
-        amount: 2,
-      },
-    }),
-  )) as FinalExecutionOutcome;
+    mintCall, mintCall,
+  )) as FinalExecutionOutcome[];
     
-  expect(result.receipts_outcome).not.toBeUndefined();
+  expect(result[0].receipts_outcome).not.toBeUndefined();
+  expect(result[1].receipts_outcome).not.toBeUndefined();
 });
 
 

--- a/packages/testing/tests/SDK/transfer.integration.test.ts
+++ b/packages/testing/tests/SDK/transfer.integration.test.ts
@@ -25,11 +25,11 @@ test('transfer token between two accounts', async () => {
   }
 
   const result = (await execute(
+    { account: signingAccount },
     transfer({
       nftContractId: TEST_TOKEN_CONTRACT,
       transfers: [{ receiverId: accountTo, tokenId: token.tokenId }],
     }),
-    { account: signingAccount },
   )) as FinalExecutionOutcome;
 
   expect(result.receipts_outcome).not.toBeUndefined();

--- a/packages/testing/tests/SDK/transferContractOwnership.integration.test.ts
+++ b/packages/testing/tests/SDK/transferContractOwnership.integration.test.ts
@@ -27,25 +27,21 @@ test('transfer contract ownership', async () => {
   
   if (data.nft_contracts[0].owner_id == 'mb_alice.testnet') {
     const aliceToBob = (await execute(
-      {
-        ...transferContractOwnership({
-          contractId: 'qrq9m4sfaf.mintspace2.testnet',
-          nextOwner: bob,
-        }),
-        gas: GAS,
-        deposit: ONE_YOCTO,
-      },
       { account: aliceAccount },
+      transferContractOwnership({
+        contractId: 'qrq9m4sfaf.mintspace2.testnet',
+        nextOwner: bob,
+      }),
     ))  as FinalExecutionOutcome;
     expect(aliceToBob.receipts_outcome).not.toBeUndefined();
   } else {
 
     const bobToAlice = (await execute(
+      { account: bobAccount },
       transferContractOwnership({
         contractId: 'qrq9m4sfaf.mintspace2.testnet',
         nextOwner: alice,
       }),  
-      { account: bobAccount },
     )) as FinalExecutionOutcome;
 
     expect(bobToAlice.receipts_outcome).not.toBeUndefined();

--- a/packages/testing/tests/execute.integration.test.ts
+++ b/packages/testing/tests/execute.integration.test.ts
@@ -1,0 +1,82 @@
+import { connect, FinalExecutionOutcome } from '@mintbase-js/auth';
+import { ownedTokens, tokensByStatus } from '@mintbase-js/data';
+import { burn, ContractCall, execute, mint, NearContractCall } from '@mintbase-js/sdk';
+import { TEST_TOKEN_CONTRACT } from '../src/constants';
+import { authenticatedKeyStore } from '../src/utils';
+
+describe('execute integration test', () => {
+  test('execute single call', async () =>{
+    const keyStore = await authenticatedKeyStore(['mb_alice.testnet']);
+    const signingAccount = await connect('mb_alice.testnet', keyStore);
+  
+    const result = (await execute(
+      { account: signingAccount },
+      mint({
+        nftContractId: TEST_TOKEN_CONTRACT,
+        ownerId: 'mb_bob.testnet',
+        reference: 'https://arweave.net/OzOg7k329BMjb-ib3AZ3cCrxf5KpChzyBAobHtulxRE',
+      }),
+    )) as FinalExecutionOutcome;
+  
+    expect(result.receipts_outcome).not.toBeUndefined();
+  });
+
+
+  test('execute with multiple methods and composition', async () => {
+    const account = 'mb_alice.testnet';
+    const keyStore = await authenticatedKeyStore([account]);
+    const signingAccount = await connect(account, keyStore);
+    const token = await ownedTokens(account, { limit: 1 });
+  
+    if (!token) {
+      throw `${account} ran out of owned tokens to burn! Mint some more...`;
+    }
+    const { listedTokens, unlistedTokens } = await tokensByStatus(
+      token[0].metadataId,
+      account,
+    );
+  
+    const tokensToBurn: string[] = [];
+  
+    if (unlistedTokens.length > 1) {
+      tokensToBurn.push(unlistedTokens[0]);
+      tokensToBurn.push(unlistedTokens[1]);
+    } 
+
+    if (tokensToBurn.length < 1) {
+      console.error('No unburned tokens for burn integration test, mint some more');
+      return;
+    }
+    
+    const burnCall1 = burn({
+      nftContractId: TEST_TOKEN_CONTRACT,
+      tokenIds: [tokensToBurn[0]],
+    });
+
+    const burnCall2 = burn({
+      nftContractId: TEST_TOKEN_CONTRACT,
+      tokenIds: [tokensToBurn[1]],
+    });
+    
+
+    const mintCall = mint({
+      nftContractId: TEST_TOKEN_CONTRACT,
+      ownerId: 'mb_bob.testnet',
+      reference: 'https://arweave.net/OzOg7k329BMjb-ib3AZ3cCrxf5KpChzyBAobHtulxRE',
+    });
+    
+    const composed: NearContractCall  = [mintCall, mintCall] as ContractCall[];
+
+    const result = (await execute(  
+      { account: signingAccount },
+      burnCall1, composed, burnCall2,
+      
+    )) as FinalExecutionOutcome;
+  
+    expect(result[0].receipts_outcome).not.toBeUndefined();
+    expect(result[1].receipts_outcome).not.toBeUndefined();
+    expect(result[2].receipts_outcome).not.toBeUndefined();
+    expect(result[3].receipts_outcome).not.toBeUndefined();
+  
+  });
+});


### PR DESCRIPTION
This pr adds support for the composition of various mb-js methods into a single call which can get executed transparently by the user as if it was a single function.
It also solves the problem of not getting status and results from batch transactions.
Integration/Unit tests were added to validate that 