### PR TITLE
Requiring media to mint

### DIFF
--- a/packages/sdk/src/mint/mint.ts
+++ b/packages/sdk/src/mint/mint.ts
@@ -6,6 +6,7 @@ import { NearContractCall } from '../execute';
 export type MintArgs =  {
   nftContractId?: string;
   reference: string;
+  media: string;
   ownerId: string;
   options?: MintOptions;
 };
@@ -26,7 +27,7 @@ export type Splits = Record<string, number>;
 export const mint = (
   args: MintArgs,
 ): NearContractCall => {
-  const { nftContractId = DEFAULT_CONTRACT_ADDRESS, reference, ownerId, options = {}  } = args;
+  const { nftContractId = DEFAULT_CONTRACT_ADDRESS, reference, media, ownerId, options = {}  } = args;
 
   const { splits, amount, royaltyPercentage } = options;
   
@@ -61,6 +62,7 @@ export const mint = (
       owner_id: ownerId,
       metadata: {
         reference: reference,
+        media: media,
       },
       num_to_mint: amount || 1,
       // 10000 = 100%


### PR DESCRIPTION
I guess this breaks omni-site. We decided a while back that on-chain media would be very desirable, as the MB way of having media in the reference blob is supported by standards, but we are about the only folks in the ecosystem doing it that way, and it's highly likely that it will cause problems with third parties wanting to integrate Mintbase.