### PR TITLE
provide queries to users on data package

### DIFF
--- a/packages/data/src/api/tokenProvenance/tokenProvenance.query.ts
+++ b/packages/data/src/api/tokenProvenance/tokenProvenance.query.ts
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-request';
 import { QUERY_OPS_PREFIX } from '../../constants';
 
-export const getTokenProvenance = gql`
+export const getTokenProvenanceQuery = gql`
 query ${QUERY_OPS_PREFIX}_getTokenProvenance(
     $tokenId: String!
     $contractAddress: String!

--- a/packages/data/src/api/tokenProvenance/tokenProvenance.ts
+++ b/packages/data/src/api/tokenProvenance/tokenProvenance.ts
@@ -3,7 +3,7 @@ import { fetchGraphQl } from '../../graphql/fetch';
 import { Pagination, ParsedDataReturn } from '../../types';
 import { parseData, validContractAddress, validTokenId } from '../../utils';
 import { errorContractAddress, errorToken } from './tokenProvenance.errors';
-import { getTokenProvenance } from './tokenProvenance.query';
+import { getTokenProvenanceQuery } from './tokenProvenance.query';
 import { TokenProvenanceData } from './tokenProvenance.types';
 
 export const tokenProvenance = async (
@@ -31,7 +31,7 @@ export const tokenProvenance = async (
   }
 
   const { data, error } = await fetchGraphQl<TokenProvenanceData>({
-    query: getTokenProvenance,
+    query: getTokenProvenanceQuery,
     variables: {
       tokenId,
       contractAddress,

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -2,3 +2,4 @@ export * from './constants';
 export * from './api/index';
 export * from './graphql/index';
 export * from './types';
+export { MB_QUERIES } from './queries';

--- a/packages/data/src/queries.ts
+++ b/packages/data/src/queries.ts
@@ -1,0 +1,27 @@
+import { attributesByMetaIdQuery } from './api/attributesByMetaId/attributesByMetaId.query';
+import { ownedNftsByStoreQuery } from './api/ownedNftsByStore/ownedNftsByStore.query';
+import { ownedStoresQuery } from './api/ownedStores/ownedStores.query';
+import { ownedTokensQuery } from './api/ownedTokens/ownedTokens.query';
+import { storeDataQuery } from './api/storeData/storeData.query';
+import { storeNftsQuery } from './api/storeNfts/storeNfts.query';
+import { tokenByIdQuery } from './api/tokenById/tokenById.query';
+import { tokenListingCountsByMetaIdQuery } from './api/tokenListingCountsByMetaId/tokenListingCountsByMetaId.query';
+import { tokenOwnerQuery } from './api/tokenOwner/tokenOwner.query';
+import { tokenOwnersByMetadataIdQuery } from './api/tokenOwnersByMetadataId/tokenOwnersByMetadataId.query';
+import { getTokenProvenanceQuery } from './api/tokenProvenance/tokenProvenance.query';
+import { tokensByStatusQuery } from './api/tokensByStatus/tokensByStatus.query';
+
+export const MB_QUERIES = {
+  attributesByMetaIdQuery: attributesByMetaIdQuery,
+  ownedNftsByStoreQuery: ownedNftsByStoreQuery,
+  ownedStoresQuery: ownedStoresQuery,
+  ownedTokensQuery: ownedTokensQuery,
+  storeDataQuery: storeDataQuery,
+  storeNftsQuery: storeNftsQuery,
+  tokenByIdQuery: tokenByIdQuery,
+  tokenListingCountsByMetaIdQuery: tokenListingCountsByMetaIdQuery,
+  tokenOwnerQuery: tokenOwnerQuery,
+  tokenOwnersByMetadataIdQuery: tokenOwnersByMetadataIdQuery,
+  getTokenProvenanceQuery: getTokenProvenanceQuery,
+  tokensByStatusQuery: tokensByStatusQuery,
+};


### PR DESCRIPTION
As a mintbase-js user I want to:

- be able to do my own methods on query fetching
- use any lib I want ex:(Apollo, urql, React Query etc..)
- dont want to use mb-js methods and implementation
- dont wanna to use graphql-request
- want to cache , revalidate etc ( apollo, react query has this features ) 
- better network status etc..


further reading:
https://blog.logrocket.com/5-graphql-clients-for-javascript-and-node-js/


React Query x  SWR x Apollo Client  x RTK-Query  x React Router
https://tanstack.com/query/v4/docs/react/comparison