### PR TITLE
ci(all): :wrench: Set clone depth in checkout for branch

### DIFF
--- a/.github/workflows/branch-publish.yml
+++ b/.github/workflows/branch-publish.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           token: ${{ secrets.TEAM_PAT }}
           ref: ${{ github.event.release.target_commitish }}
 


### PR DESCRIPTION
Fixes possible race condition with two simultaneous merges to alpha