### PR TITLE
feat(sdk): :sparkles: Support specifying token ids

### DIFF
--- a/packages/sdk/src/mint/mint.test.ts
+++ b/packages/sdk/src/mint/mint.test.ts
@@ -116,6 +116,7 @@ describe('mint method tests', () => {
       metadata: { reference, media },
       ownerId: ownerId,
       options: options,
+      tokenIdsToMint: [123, 456],
     });
 
     expect(args).toEqual({
@@ -139,6 +140,7 @@ describe('mint method tests', () => {
           test: 5000,
           test2: 5000,
         },
+        token_ids_to_mint: [123, 456],
       },
       deposit: '10013150000000000000000000',
       gas: GAS,

--- a/packages/sdk/src/mint/mint.ts
+++ b/packages/sdk/src/mint/mint.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js';
 import { mbjs } from '../config/config';
-import { DEPOSIT_CONSTANTS, GAS, ONE_YOCTO, YOCTO_PER_BYTE, MINTING_FEE } from '../constants';
+import { DEPOSIT_CONSTANTS, GAS, YOCTO_PER_BYTE, MINTING_FEE } from '../constants';
 import { ERROR_MESSAGES } from '../errorMessages';
 import { MintArgs, MintArgsResponse, NearContractCall, TokenMetadata, TOKEN_METHOD_NAMES } from '../types';
 
@@ -19,6 +19,7 @@ export const mint = (
     options = {},
     noMedia = false,
     noReference = false,
+    tokenIdsToMint,
   } = args;
 
   const { splits, amount, royaltyPercentage } = options;
@@ -66,6 +67,7 @@ export const mint = (
       // 10_000 = 100% (see above note)
       royalty_args: !splits ? null : { split_between: splits, percentage: royaltyPercentage * 10_000 },
       split_owners: splits || null,
+      token_ids_to_mint: tokenIdsToMint,
     },
     methodName: TOKEN_METHOD_NAMES.MINT,
     gas: GAS,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -177,6 +177,7 @@ export type MintArgs =  {
   options?: MintOptions;
   noMedia?: boolean;     // explicit opt-in to NFT without media, breaks wallets
   noReference?: boolean; // explicit opt-in to NFT without reference
+  tokenIdsToMint?: number[];
 };
 
 export type TokenMetadata = {
@@ -295,6 +296,7 @@ export interface MintArgsResponse {
   // 10000 = 100%
   royalty_args: { split_between: Splits; percentage: number } | null;
   split_owners: Splits | null;
+  token_ids_to_mint?: number[];
 }
 
 export interface TransferContractOwnershipArgsResponse {

--- a/packages/testing/src/constants.ts
+++ b/packages/testing/src/constants.ts
@@ -1,2 +1,3 @@
 export const SECRETS_REPO_PATH = 'projects/185858989453/secrets/';
 export const TEST_TOKEN_CONTRACT = 'mb_store.mintspace2.testnet';
+export const LICENSE_TEST_TOKEN_CONTRACT = 'creativelicense2.testnet';

--- a/packages/testing/tests/workflows/mint.w.upload.integration.test.ts
+++ b/packages/testing/tests/workflows/mint.w.upload.integration.test.ts
@@ -1,12 +1,18 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { TEST_TOKEN_CONTRACT } from '../../src/constants';
+import {
+  LICENSE_TEST_TOKEN_CONTRACT,
+  TEST_TOKEN_CONTRACT,
+} from '../../src/constants';
 import { execute, mint } from '@mintbase-js/sdk/src';
 import { uploadBuffer } from '@mintbase-js/storage';
 import { FinalExecutionOutcome } from '@near-wallet-selector/core';
 import { connect } from '@mintbase-js/auth';
 import { authenticatedKeyStore, writeGasTelemetryToFirestore } from '../../src/utils';
+
+// const USE_TEST_CONTRACT = TEST_TOKEN_CONTRACT;
+const USE_TEST_CONTRACT = LICENSE_TEST_TOKEN_CONTRACT;
 
 test('upload media and mint tokens', async () => {
 
@@ -51,24 +57,28 @@ test('upload media and mint tokens', async () => {
     'metadata.json',
   );
 
+  const randInt = (): number => Number(Math.random().toString().slice(2, 19));
+
   const results = (await execute(
     { account: signingAccount },
 
     mint({
-      contractAddress: TEST_TOKEN_CONTRACT,
+      contractAddress: USE_TEST_CONTRACT,
       ownerId: 'mb_alice.testnet',
       metadata: {
         reference: referenceIdOne,
         media: mediaIdOne,
       },
+      tokenIdsToMint: [randInt()],
     }),
     mint({
-      contractAddress: TEST_TOKEN_CONTRACT,
+      contractAddress: USE_TEST_CONTRACT,
       ownerId: 'mb_alice.testnet',
       metadata: {
         reference: referenceIdTwo,
         media: mediaIdTwo,
       },
+      tokenIdsToMint: [randInt()],
     }),
 
   )) as FinalExecutionOutcome[];


### PR DESCRIPTION
This will only work on contracts which support the feature.  Currently, this is a single wasm deployed to a testnet account. 