### PR TITLE
Use anon as default key

### DIFF
--- a/packages/sdk/src/config/config.client.test.ts
+++ b/packages/sdk/src/config/config.client.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { ConfigOptions, NEAR_NETWORKS } from '../types';
-import { DEFAULT_API_KEY_AS_WARNING } from './config';
+import { DEFAULT_API_KEY } from './config';
 import { MAINNET_MOCK, TESTNET_MOCK } from './config.mocks';
 
 describe('test mbjs namespace', () => {
@@ -30,7 +30,7 @@ describe('test mbjs namespace', () => {
     expect(configModule.setGlobalEnv).toHaveBeenCalledWith(config);
     expect(configModule.mbjs.keys).toEqual({
       ...TESTNET_MOCK,
-      apiKey: DEFAULT_API_KEY_AS_WARNING,
+      apiKey: DEFAULT_API_KEY,
     });
 
   });
@@ -53,7 +53,7 @@ describe('test mbjs namespace', () => {
     expect(configModule.setGlobalEnv).toHaveBeenCalledWith(config);
     expect(configModule.mbjs.keys).toEqual({
       ...MAINNET_MOCK,
-      apiKey: DEFAULT_API_KEY_AS_WARNING,
+      apiKey: DEFAULT_API_KEY,
     });
 
   });

--- a/packages/sdk/src/config/config.ts
+++ b/packages/sdk/src/config/config.ts
@@ -12,7 +12,7 @@ export const isDebugMode = Boolean(typeof window == 'undefined' && process?.env?
 export const hasContractAddress =  Boolean(typeof window == 'undefined' && process?.env?.CONTRACT_ADDRESS);
 export const hasCallbackUrl =  Boolean(typeof window == 'undefined' && process?.env?.CALLBACK_URL);
 
-export const DEFAULT_API_KEY_AS_WARNING = '<set-me-by-calling-mbjs.config>';
+export const DEFAULT_API_KEY = 'anon';
 
 const defaultContractAddress = isProcessEnv ? MINTBASE_CONTRACTS[process.env.NEAR_NETWORK] : MINTBASE_CONTRACTS[NEAR_NETWORKS.TESTNET];
 
@@ -26,13 +26,12 @@ export const CONFIG_KEYS: MbJsKeysObject = {
   contractAddress: hasContractAddress ? process.env.CONTRACT_ADDRESS : defaultContractAddress,
   marketAddress:  isProcessEnv ? MARKET_CONTRACT_ADDRESS[process.env.NEAR_NETWORK] : MARKET_CONTRACT_ADDRESS[NEAR_NETWORKS.TESTNET],
   mbContract: isProcessEnv ? MINTBASE_CONTRACTS[process.env.NEAR_NETWORK] : MINTBASE_CONTRACTS[NEAR_NETWORKS.TESTNET],
-  apiKey: isProcessEnv ? process.env.MINTBASE_API_KEY : DEFAULT_API_KEY_AS_WARNING,
+  apiKey: isProcessEnv ? process.env.MINTBASE_API_KEY : DEFAULT_API_KEY,
   debugMode: isDebugMode ? true : false,
   isSet:  isProcessEnv ? true : false,
 };
 
 export const setGlobalEnv = (configObj: ConfigOptions): MbJsKeysObject => {
-
   const globalConfig: MbJsKeysObject = {
     network: configObj.network as Network,
     graphqlUrl: GRAPHQL_ENDPOINTS[configObj.network],
@@ -42,7 +41,7 @@ export const setGlobalEnv = (configObj: ConfigOptions): MbJsKeysObject => {
     marketAddress: MARKET_CONTRACT_ADDRESS[configObj.network],
     debugMode: configObj.network == NEAR_NETWORKS.TESTNET,
     mbContract: MINTBASE_CONTRACTS[configObj.network],
-    apiKey: configObj.apiKey ?? DEFAULT_API_KEY_AS_WARNING,
+    apiKey: configObj.apiKey ?? DEFAULT_API_KEY,
     isSet: true,
   };
 

--- a/packages/storage/src/uploadReference.browser.test.ts
+++ b/packages/storage/src/uploadReference.browser.test.ts
@@ -3,11 +3,15 @@
  */
 import { getFormDataFromJson, uploadReference } from './uploads';
 import fetchMock from 'jest-fetch-mock';
+import { mbjs } from '@mintbase-js/sdk';
 fetchMock.enableMocks();
+
+const FAKE_API_KEY = 'foo';
 
 describe('upload tests in browser', () => {
   beforeAll(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => null);
+    mbjs.config({ apiKey: FAKE_API_KEY });
   });
 
   beforeEach(() => {
@@ -34,6 +38,8 @@ describe('upload tests in browser', () => {
 
     const result = await uploadReference(referenceObject);
 
+    const [call] = fetchMock.mock.calls;
+    expect((call as any)[1].headers['mb-api-key']).toBe(FAKE_API_KEY);
     expect(result).toEqual({
       status: 200,
     });


### PR DESCRIPTION
Prevents issues arising from when api key may not be set