### PR TITLE
refactor(data): :recycle: Refactor nearPrice data method to use promi…

### DIFF
--- a/packages/data/src/api/nearPrice/nearPrice.mock.ts
+++ b/packages/data/src/api/nearPrice/nearPrice.mock.ts
@@ -1,2 +1,0 @@
-
-export const nearPriceMock = '1490000';

--- a/packages/data/src/api/nearPrice/nearPrice.ts
+++ b/packages/data/src/api/nearPrice/nearPrice.ts
@@ -1,40 +1,37 @@
+import fetch from 'isomorphic-unfetch';
 import { BINANCE_API, COIN_GECKO_API } from '../../constants';
 import { ParsedDataReturn } from '../../types';
 import { parseData } from '../../utils';
 import {
-  BinanceNearPriceData,
+  NearPriceData,
   CoinGeckoNearPriceData,
-  NearPriceError,
 } from './nearPrice.types';
 
-export const nearPriceFallback = async (): Promise<CoinGeckoNearPriceData> => {
-  const geckoApi = await fetch(COIN_GECKO_API);
-  const data = geckoApi.json();
+
+export const fetchPriceFromCoinGecko = async (): Promise<NearPriceData> => {
+  const req = await fetch(COIN_GECKO_API);
+  const data = await req.json() as CoinGeckoNearPriceData;
+  return { price: data.near.usd };
+};
+
+export const fetchPriceFromBinance = async (): Promise<NearPriceData> => {
+  const req = await fetch(BINANCE_API);
+  const data = await req.json() as NearPriceData;
   return data;
 };
 
-const nearPriceData = async (): Promise<string | NearPriceError> => {
-  try {
-    const req = await fetch(BINANCE_API);
-
-    const res: BinanceNearPriceData = await req.json();
-
-    if (!res.price) {
-      const price = await nearPriceFallback();
-      return price.near.usd;
-    }
-
-    return res.price;
-  } catch (error) {
-    return { error: 'Error fetching NEAR price' };
-  }
-};
-
 export const nearPrice = async (): Promise<ParsedDataReturn<string>> => {
-  const price = await nearPriceData();
-  const validPrice = typeof price === 'string';
+  try {
+    const res = await Promise.any([
+      fetchPriceFromCoinGecko(),
+      fetchPriceFromBinance(),
+    ]);
 
-  const errorMsg = !validPrice ? 'Error fetching NEAR price' : '';
-
-  return parseData(validPrice ? price : '', errorMsg, errorMsg);
+    return parseData(res.price);
+  } catch (err) {
+    console.error(
+      `No price data was able to be fetched ${JSON.stringify(err.errors)}`,
+    );
+    return parseData(null, err, err.message);
+  }
 };

--- a/packages/data/src/api/nearPrice/nearPrice.types.ts
+++ b/packages/data/src/api/nearPrice/nearPrice.types.ts
@@ -1,11 +1,9 @@
-export interface BinanceNearPriceData  {
+export interface NearPriceData  {
     price?: string;
 }
-
 export interface CoinGeckoNearPriceData {
-    near?: {usd: string};
+    near?: {
+        usd: string;
+    };
 }
 
-export interface NearPriceError {
-    error: string;
-} 

--- a/packages/data/src/utils.ts
+++ b/packages/data/src/utils.ts
@@ -1,7 +1,7 @@
 import { ParsedDataReturn } from './types';
 
 
-export const parseData = <T>(data: T, error: null | string, errorMsg: string): ParsedDataReturn<T> => {
+export const parseData = <T>(data: T, error?: null | string, errorMsg?: string): ParsedDataReturn<T> => {
   if (error) {
     console.error(errorMsg);
     return { error: error };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "target": "es6",
     "sourceMap": true,
     "lib": [
+      "ES2021",
       "es6",
       "dom",
     ]


### PR DESCRIPTION
The binance API isn't returning and the fallback isn't working because res.json() throws.  This creates a condition where the prices are fetched from both and the first to win the race back is returned via promise.any