### PR TITLE
Add async keyword for signAndSendTransaction

### DIFF
--- a/packages/wallet/src/mintbase-wallet.ts
+++ b/packages/wallet/src/mintbase-wallet.ts
@@ -172,7 +172,7 @@ export const MintbaseWallet: WalletBehaviourFactory<
     return;
   };
 
-  const signAndSendTransaction = ({
+  const signAndSendTransaction =  async ({
     receiverId,
     actions,
     signerId,


### PR DESCRIPTION
# Description

This small change is needed because `signAndSendTransaction` is an `async` function for all wallet types.

One of the reasons this is needed is the fact that the code is running `synchronously` for this function and the `.then` or `.catch` in dApps gets ignored when `signAndSendTransaction` is called.

---
This change is required because if `signAndSendTransaction` throws or returns anything it just shows in console but it does not get returned to the dApp.

![mintbase-signAndSendTransaction-error](https://github.com/Mintbase/mintbase-js/assets/95851345/70bbabe8-fd0e-4af3-80d8-d1d187e34c8e)

---

After this change we can catch and show the error to users:

![image](https://github.com/Mintbase/mintbase-js/assets/95851345/99a5de7d-1451-4f59-afce-4707ad47482e)
