### PR TITLE
Fix type of gas price

### DIFF
--- a/packages/rpc/src/methods/getLatestGasPrice.ts
+++ b/packages/rpc/src/methods/getLatestGasPrice.ts
@@ -1,6 +1,6 @@
 import { requestFromNearRpc } from '../util';
 
-export const getLatestGasPrice = async (): Promise<number> => {
+export const getLatestGasPrice = async (): Promise<string> => {
   const res = await requestFromNearRpc({
     jsonrpc: '2.0',
     id: 'dontcare',


### PR DESCRIPTION
Return type should be string not number, see example response in the official docs: https://docs.near.org/api/rpc/gas