### PR TITLE
add window.mbjs.callbackUrl back to execute to all wallets

### DIFF
--- a/packages/sdk/src/execute/execute.test.ts
+++ b/packages/sdk/src/execute/execute.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { execute } from './execute';
 import { MAX_GAS, ONE_YOCTO } from '../constants';

--- a/packages/sdk/src/execute/execute.ts
+++ b/packages/sdk/src/execute/execute.ts
@@ -24,6 +24,9 @@ export const execute = async (
 
   let callbackFinal = callbackUrl;
 
+  const shouldGetFromMbjs = callbackUrl?.length < 1 || callbackUrl === undefined && 
+   window?.['mbjs']?.keys?.callbackUrl && window?.['mbjs']?.keys?.callbackUrl.length > 0; 
+
   if (wallet?.id == 'mintbase-wallet') {
     if (callbackUrl?.length < 1 || callbackUrl === undefined) {
       let mbjsCallbackUrl = '';
@@ -42,8 +45,7 @@ export const execute = async (
     }
   }
 
-  if (callbackUrl?.length < 1 || callbackUrl === undefined &&  window?.['mbjs']?.keys?.callbackUrl &&
-        window?.['mbjs']?.keys?.callbackUrl.length > 0) {
+  if (shouldGetFromMbjs) {
     callbackFinal =  window?.['mbjs']?.keys?.callbackUrl;
   } 
 

--- a/packages/sdk/src/execute/execute.ts
+++ b/packages/sdk/src/execute/execute.ts
@@ -42,6 +42,11 @@ export const execute = async (
     }
   }
 
+  if (callbackUrl?.length < 1 || callbackUrl === undefined &&  window?.['mbjs']?.keys?.callbackUrl &&
+        window?.['mbjs']?.keys?.callbackUrl.length > 0) {
+    callbackFinal =  window?.['mbjs']?.keys?.callbackUrl;
+  } 
+
   const outcomes = await genericBatchExecute(
     flattenArgs(calls),
     wallet,

--- a/packages/sdk/src/execute/execute.ts
+++ b/packages/sdk/src/execute/execute.ts
@@ -25,17 +25,17 @@ export const execute = async (
   let callbackFinal = callbackUrl;
 
   const shouldGetFromMbjs = callbackUrl?.length < 1 || callbackUrl === undefined && 
-   window?.['mbjs']?.keys?.callbackUrl && window?.['mbjs']?.keys?.callbackUrl.length > 0; 
+   window?.['mbjs']?.callbackUrl && window?.['mbjs']?.callbackUrl.length > 0; 
 
   if (wallet?.id == 'mintbase-wallet') {
     if (callbackUrl?.length < 1 || callbackUrl === undefined) {
       let mbjsCallbackUrl = '';
 
       if (
-        window?.['mbjs']?.keys?.callbackUrl &&
-        window?.['mbjs']?.keys?.callbackUrl.length > 0
+        window?.['mbjs']?.callbackUrl &&
+        window?.['mbjs']?.callbackUrl.length > 0
       ) {
-        mbjsCallbackUrl = window?.['mbjs']?.keys?.callbackUrl;
+        mbjsCallbackUrl = window?.['mbjs']?.callbackUrl;
       }
 
       const globalCBUrl =
@@ -46,7 +46,7 @@ export const execute = async (
   }
 
   if (shouldGetFromMbjs) {
-    callbackFinal =  window?.['mbjs']?.keys?.callbackUrl;
+    callbackFinal =  window?.['mbjs']?.callbackUrl;
   } 
 
   const outcomes = await genericBatchExecute(


### PR DESCRIPTION
so, it was removed due to Mintbase Wallet gets the callbackUrl straight from WalletConext and localStorage, but other wallets can get from mbjs.config straight, no need to be passing in each execute ( if we pass the callbackUrl on execute it will work )

the method checkCallbackUrl on execute.utils.ts, it was the old one we had on the marketplace, now is available to everyone