### PR TITLE
fix(wallet): Encode nonces as base64 on redirect

### DIFF
--- a/packages/wallet/src/bitte-wallet.ts
+++ b/packages/wallet/src/bitte-wallet.ts
@@ -217,7 +217,7 @@ export const BitteWallet: WalletBehaviourFactory<
 
     const newUrl = new URL(`${metadata.walletUrl}/sign-message`);
     newUrl.searchParams.set('message', message);
-    newUrl.searchParams.set('nonce', nonce);
+    newUrl.searchParams.set('nonce', Buffer.from(nonce).toString('base64'));
     newUrl.searchParams.set('recipient', recipient);
     newUrl.searchParams.set('callbackUrl', cbUrl);
     window.location.assign(newUrl.toString());
@@ -230,7 +230,7 @@ export const BitteWallet: WalletBehaviourFactory<
     newUrl.searchParams.set('accountId', accountId);
     newUrl.searchParams.set('publicKey', publicKey);
     newUrl.searchParams.set('signature', signature);
-    newUrl.searchParams.set('nonce', nonce);
+    newUrl.searchParams.set('nonce', Buffer.from(nonce).toString('base64'));
     newUrl.searchParams.set('recipient', recipient);
     newUrl.searchParams.set('callbackUrl', callbackUrl);
 

--- a/packages/wallet/src/mintbase-wallet.ts
+++ b/packages/wallet/src/mintbase-wallet.ts
@@ -217,7 +217,7 @@ export const MintbaseWallet: WalletBehaviourFactory<
 
     const newUrl = new URL(`${metadata.walletUrl}/sign-message`);
     newUrl.searchParams.set('message', message);
-    newUrl.searchParams.set('nonce', nonce);
+    newUrl.searchParams.set('nonce', Buffer.from(nonce).toString('base64'));
     newUrl.searchParams.set('recipient', recipient);
     newUrl.searchParams.set('callbackUrl', cbUrl);
     window.location.assign(newUrl.toString());
@@ -230,7 +230,7 @@ export const MintbaseWallet: WalletBehaviourFactory<
     newUrl.searchParams.set('accountId', accountId);
     newUrl.searchParams.set('publicKey', publicKey);
     newUrl.searchParams.set('signature', signature);
-    newUrl.searchParams.set('nonce', nonce);
+    newUrl.searchParams.set('nonce', Buffer.from(nonce).toString('base64'));
     newUrl.searchParams.set('recipient', recipient);
     newUrl.searchParams.set('callbackUrl', callbackUrl);
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where `nonce` was not encoded as base64 in URL search parameters.
- Updated the `nonce` parameter encoding in two functions to ensure it is correctly handled during redirects.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mintbase-wallet.ts</strong><dd><code>Encode `nonce` as base64 in URL parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/wallet/src/mintbase-wallet.ts

<li>Encode <code>nonce</code> as base64 in URL search parameters<br> <li> Updated <code>nonce</code> parameter in two functions<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/mintbase-js/pull/530/files#diff-9185fb91b52e06e702f448ca0818e8c83cce2dd7026334ab60f209a0d00f2e18">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

