### PR TITLE
Add creatorAddress to ReferenceObject

### DIFF
--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -10,9 +10,6 @@ export type ReferenceObject = {
   tags?: string[];
   extra?: Trait[];
   history?: string[];
-  creatorAddress?: string;
-  metadata_content_flag?: string;
-  id?: string;
 }
 
 export type Trait = {

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -1,6 +1,7 @@
 export type ReferenceObject = {
   title?: string;
   description?: string;
+  creatorAddress?: string;
   media?: File | string;
   media_type?: string;
   animation_url?: File | string;

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -1,7 +1,6 @@
 export type ReferenceObject = {
   title?: string;
   description?: string;
-  creatorAddress?: string;
   media?: File | string;
   media_type?: string;
   animation_url?: File | string;
@@ -11,6 +10,9 @@ export type ReferenceObject = {
   tags?: string[];
   extra?: Trait[];
   history?: string[];
+  creatorAddress?: string;
+  metadata_content_flag?: string;
+  id?: string;
 }
 
 export type Trait = {

--- a/packages/storage/src/uploads.ts
+++ b/packages/storage/src/uploads.ts
@@ -65,7 +65,7 @@ export const uploadFile = async (
  * @param ReferenceObject A json reference object to upload
  */
 export const uploadReference = async (
-  referenceObject: ReferenceObject,
+  referenceObject: ReferenceObject & { [k: string]: unknown },
 ): Promise<ArweaveResponse> => {
 
   if (Object.keys(referenceObject).length == 0) {


### PR DESCRIPTION
### **User description**
This field is missing and causes users to have unnecessary casts on upload.


___

### **PR Type**
enhancement


___

### **Description**
- Added a new `creatorAddress` field to the `ReferenceObject` type in the TypeScript file. This change helps to avoid unnecessary type casting by users during uploads.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add `creatorAddress` field to `ReferenceObject` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/storage/src/types.ts

- Added `creatorAddress` field to `ReferenceObject` type.



</details>


  </td>
  <td><a href="https://github.com/Mintbase/mintbase-js/pull/553/files#diff-d6f7a6e48650fc05c9bee9fe252435b9d02099918d2b0dfa536dd1b40990f712">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

